### PR TITLE
feat: add pagination to GET /nodes endpoint

### DIFF
--- a/charts/murmurations/templates/cronjob/nodecleanup.yaml
+++ b/charts/murmurations/templates/cronjob/nodecleanup.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nodecleanup
 spec:
-  schedule: "*/1 * * * *"
+  schedule: "*/10 * * * *"
   jobTemplate:
     spec:
       template:

--- a/common/elastic/client.go
+++ b/common/elastic/client.go
@@ -66,10 +66,12 @@ func (c *esClient) IndexWithID(index string, id string, doc interface{}) (*elast
 	return result, nil
 }
 
-func (c *esClient) Search(index string, query elastic.Query) (*elastic.SearchResult, error) {
+func (c *esClient) Search(index string, q *Query) (*elastic.SearchResult, error) {
 	ctx := context.Background()
 	result, err := c.client.Search(index).
-		Query(query).
+		Query(q.Query).
+		From(int(q.From)).
+		Size(int(q.Size)).
 		RestTotalHitsAsInt(true).
 		Do(ctx)
 	if err != nil {

--- a/common/elastic/client_interface.go
+++ b/common/elastic/client_interface.go
@@ -19,7 +19,7 @@ type esClientInterface interface {
 	CreateMappings([]Index) error
 	Index(string, interface{}) (*elastic.IndexResponse, error)
 	IndexWithID(string, string, interface{}) (*elastic.IndexResponse, error)
-	Search(string, elastic.Query) (*elastic.SearchResult, error)
+	Search(string, *Query) (*elastic.SearchResult, error)
 	Delete(string, string) error
 }
 

--- a/common/elastic/mock_client.go
+++ b/common/elastic/mock_client.go
@@ -22,7 +22,7 @@ func (c *mockClient) IndexWithID(index string, id string, doc interface{}) (*ela
 	return nil, nil
 }
 
-func (c *mockClient) Search(index string, query elastic.Query) (*elastic.SearchResult, error) {
+func (c *mockClient) Search(index string, query *Query) (*elastic.SearchResult, error) {
 	return nil, nil
 }
 

--- a/common/elastic/query.go
+++ b/common/elastic/query.go
@@ -6,7 +6,11 @@ import (
 	"github.com/olivere/elastic"
 )
 
-type Query elastic.Query
+type Query struct {
+	Query elastic.Query
+	From  float64
+	Size  float64
+}
 
 func NewQueries() []elastic.Query {
 	return make([]elastic.Query, 0)

--- a/common/elastic/query.go
+++ b/common/elastic/query.go
@@ -8,8 +8,8 @@ import (
 
 type Query struct {
 	Query elastic.Query
-	From  float64
-	Size  float64
+	From  int64
+	Size  int64
 }
 
 func NewQueries() []elastic.Query {

--- a/common/pagination/pagination.go
+++ b/common/pagination/pagination.go
@@ -1,0 +1,11 @@
+package pagination
+
+import "math"
+
+func GetTotalPages(numberOfResults int64, sizeSize float64) int64 {
+	pages := math.Ceil(float64(numberOfResults) / sizeSize)
+	if numberOfResults == 0.0 {
+		return 1
+	}
+	return int64(pages)
+}

--- a/common/pagination/pagination.go
+++ b/common/pagination/pagination.go
@@ -2,9 +2,17 @@ package pagination
 
 import "math"
 
-func GetTotalPages(numberOfResults int64, sizeSize float64) int64 {
-	pages := math.Ceil(float64(numberOfResults) / sizeSize)
-	if numberOfResults == 0.0 {
+func From(page int64, pageSize int64) int64 {
+	return int64(math.Max(0, float64(pageSize*(page-1))))
+}
+
+func Size(pageSize int64) int64 {
+	return int64(math.Min(500, math.Max(1, float64(pageSize))))
+}
+
+func TotalPages(numberOfResults int64, pageSize int64) int64 {
+	pages := math.Ceil(float64(numberOfResults / pageSize))
+	if pages == 0.0 {
 		return 1
 	}
 	return int64(pages)

--- a/common/pagination/pagination.go
+++ b/common/pagination/pagination.go
@@ -11,7 +11,7 @@ func Size(pageSize int64) int64 {
 }
 
 func TotalPages(numberOfResults int64, pageSize int64) int64 {
-	pages := math.Ceil(float64(numberOfResults / pageSize))
+	pages := math.Ceil(float64(numberOfResults) / float64(pageSize))
 	if pages == 0.0 {
 		return 1
 	}

--- a/services/index/internal/domain/node/node_dao.go
+++ b/services/index/internal/domain/node/node_dao.go
@@ -167,7 +167,7 @@ func (node *Node) Search(q *query.EsQuery) (*query.QueryResults, resterr.RestErr
 	return &query.QueryResults{
 		Result:          queryResults,
 		NumberOfResults: result.Hits.TotalHits,
-		TotalPages:      pagination.GetTotalPages(result.Hits.TotalHits, q.PageSize),
+		TotalPages:      pagination.TotalPages(result.Hits.TotalHits, q.PageSize),
 	}, nil
 }
 

--- a/services/index/internal/domain/node/node_dao.go
+++ b/services/index/internal/domain/node/node_dao.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MurmurationsNetwork/MurmurationsServices/common/jsonutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/common/logger"
 	"github.com/MurmurationsNetwork/MurmurationsServices/common/mongoutil"
+	"github.com/MurmurationsNetwork/MurmurationsServices/common/pagination"
 	"github.com/MurmurationsNetwork/MurmurationsServices/common/resterr"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/internal/adapter/mongo/nodes_db"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/internal/domain/query"
@@ -143,27 +144,31 @@ func (node *Node) setPosted() error {
 	return nil
 }
 
-func (node *Node) Search(q *query.EsQuery) (query.QueryResults, resterr.RestErr) {
+func (node *Node) Search(q *query.EsQuery) (*query.QueryResults, resterr.RestErr) {
 	result, err := elastic.Client.Search(constant.ESIndex.Node, q.Build())
 	if err != nil {
 		return nil, resterr.NewInternalServerError("Error when trying to search documents.", errors.New("database error"))
 	}
 
-	queryResults := make(query.QueryResults, result.TotalHits())
-	for index, hit := range result.Hits.Hits {
+	queryResults := make([]query.QueryResult, 0)
+	for _, hit := range result.Hits.Hits {
 		bytes, _ := hit.Source.MarshalJSON()
 		var result query.QueryResult
 		if err := json.Unmarshal(bytes, &result); err != nil {
 			return nil, resterr.NewInternalServerError("Error when trying to parse response.", errors.New("database error"))
 		}
-		queryResults[index] = result
+		queryResults = append(queryResults, result)
 	}
 
 	if len(queryResults) == 0 {
 		return nil, resterr.NewNotFoundError("No items found matching given criteria.")
 	}
 
-	return queryResults, nil
+	return &query.QueryResults{
+		Result:          queryResults,
+		NumberOfResults: result.Hits.TotalHits,
+		TotalPages:      pagination.GetTotalPages(result.Hits.TotalHits, q.PageSize),
+	}, nil
 }
 
 func (node *Node) Delete() resterr.RestErr {

--- a/services/index/internal/domain/query/es_query_dao.go
+++ b/services/index/internal/domain/query/es_query_dao.go
@@ -1,8 +1,12 @@
 package query
 
-import "github.com/MurmurationsNetwork/MurmurationsServices/common/elastic"
+import (
+	"math"
 
-func (q *EsQuery) Build() elastic.Query {
+	"github.com/MurmurationsNetwork/MurmurationsServices/common/elastic"
+)
+
+func (q *EsQuery) Build() *elastic.Query {
 	query := elastic.NewBoolQuery()
 
 	subQueries := elastic.NewQueries()
@@ -30,5 +34,9 @@ func (q *EsQuery) Build() elastic.Query {
 
 	query.Must(subQueries...).Filter(filters...)
 
-	return query
+	return &elastic.Query{
+		Query: query,
+		From:  math.Max(0, q.PageSize*(q.Page-1)),
+		Size:  math.Min(500, math.Max(1, q.PageSize)),
+	}
 }

--- a/services/index/internal/domain/query/es_query_dao.go
+++ b/services/index/internal/domain/query/es_query_dao.go
@@ -1,9 +1,8 @@
 package query
 
 import (
-	"math"
-
 	"github.com/MurmurationsNetwork/MurmurationsServices/common/elastic"
+	"github.com/MurmurationsNetwork/MurmurationsServices/common/pagination"
 )
 
 func (q *EsQuery) Build() *elastic.Query {
@@ -36,7 +35,7 @@ func (q *EsQuery) Build() *elastic.Query {
 
 	return &elastic.Query{
 		Query: query,
-		From:  math.Max(0, q.PageSize*(q.Page-1)),
-		Size:  math.Min(500, math.Max(1, q.PageSize)),
+		From:  pagination.From(q.Page, q.PageSize),
+		Size:  pagination.Size(q.PageSize),
 	}
 }

--- a/services/index/internal/domain/query/es_query_dto.go
+++ b/services/index/internal/domain/query/es_query_dto.go
@@ -1,18 +1,25 @@
 package query
 
 type EsQuery struct {
-	Schema      *string `form:"schema"`
-	LastValidated *int64  `form:"last_validated"`
+	Schema        *string `form:"schema"`
+	LastValidated *int64  `form:"last_validated,default=0"`
 
-	Lat    *float64 `form:"lat"`
-	Lon    *float64 `form:"lon"`
+	Lat   *float64 `form:"lat"`
+	Lon   *float64 `form:"lon"`
 	Range *string  `form:"range"`
 
 	Locality *string `form:"locality"`
 	Region   *string `form:"region"`
 	Country  *string `form:"country"`
+
+	Page     float64 `form:"page,default=0"`
+	PageSize float64 `form:"page_size,default=30"`
 }
 
 type QueryResult map[string]interface{}
 
-type QueryResults []QueryResult
+type QueryResults struct {
+	Result          []QueryResult
+	NumberOfResults int64
+	TotalPages      int64
+}

--- a/services/index/internal/domain/query/es_query_dto.go
+++ b/services/index/internal/domain/query/es_query_dto.go
@@ -12,8 +12,8 @@ type EsQuery struct {
 	Region   *string `form:"region"`
 	Country  *string `form:"country"`
 
-	Page     float64 `form:"page,default=0"`
-	PageSize float64 `form:"page_size,default=30"`
+	Page     int64 `form:"page,default=0"`
+	PageSize int64 `form:"page_size,default=30"`
 }
 
 type QueryResult map[string]interface{}

--- a/services/index/internal/domain/query/marshaller.go
+++ b/services/index/internal/domain/query/marshaller.go
@@ -1,9 +1,21 @@
 package query
 
+type meta struct {
+	NumberOfResults int64 `json:"number_of_results"`
+	TotalPages      int64 `json:"total_pages"`
+}
+
 type respond struct {
 	Data interface{} `json:"data,omitempty"`
+	Meta meta        `json:"meta,omitempty"`
 }
 
 func (results QueryResults) Marshall() interface{} {
-	return respond{Data: results}
+	return respond{
+		Data: results.Result,
+		Meta: meta{
+			TotalPages:      results.TotalPages,
+			NumberOfResults: results.NumberOfResults,
+		},
+	}
 }

--- a/services/index/internal/service/node_service.go
+++ b/services/index/internal/service/node_service.go
@@ -23,7 +23,7 @@ type nodesServiceInterface interface {
 	GetNode(nodeId string) (*node.Node, resterr.RestErr)
 	SetNodeValid(node node.Node) error
 	SetNodeInvalid(node node.Node) error
-	Search(query *query.EsQuery) (query.QueryResults, resterr.RestErr)
+	Search(query *query.EsQuery) (*query.QueryResults, resterr.RestErr)
 	Delete(nodeId string) resterr.RestErr
 }
 
@@ -82,7 +82,7 @@ func (s *nodesService) SetNodeInvalid(node node.Node) error {
 	return nil
 }
 
-func (s *nodesService) Search(query *query.EsQuery) (query.QueryResults, resterr.RestErr) {
+func (s *nodesService) Search(query *query.EsQuery) (*query.QueryResults, resterr.RestErr) {
 	dao := node.Node{}
 	result, err := dao.Search(query)
 	if err != nil {


### PR DESCRIPTION
resolves #43

Note:

`from and size` won't work properly if the query result is more than 10,000 items. (In our case when `number_of_results` >= 10,000)

![image](https://user-images.githubusercontent.com/11765228/99787245-75e62480-2b5a-11eb-8ac0-356a74779468.png)


[Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html)