### PR TITLE
fix: fix tls for cdn and cdn-test

### DIFF
--- a/charts/murmurations/charts/ingress/templates/ingress/ingress.yaml
+++ b/charts/murmurations/charts/ingress/templates/ingress/ingress.yaml
@@ -17,6 +17,7 @@ spec:
       - index.murmurations.network
       - library.murmurations.network
       - data-proxy.murmurations.network
+      - cdn.murmurations.network
       - temp-cdn.murmurations.network
       secretName: murmurations-network-tls
   {{- else if eq .Values.global.env "staging" }}
@@ -25,6 +26,7 @@ spec:
       - test-index.murmurations.network
       - test-library.murmurations.network
       - test-data-proxy.murmurations.network
+      - test-cdn.murmurations.network
       - temp-test-cdn.murmurations.network
       secretName: murmurations-tech-tls
   {{- else if eq .Values.global.env "pretest" }}


### PR DESCRIPTION
Related issue: #364 