### PR TITLE
style: Set Up Pre-commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.52.2
+    hooks:
+      - id: golangci-lint
+
+  - repo: https://github.com/segmentio/golines
+    rev: v0.11.0
+    hooks:
+      - id: golines
+        entry: golines -m 80 -w .


### PR DESCRIPTION
### Description

1. `golangci-lint`: This is a popular linter for Go.

2. `golines`: This tool automatically shortens long lines in Go code. It's configured to set the maximum line length to 80 characters and write the changes back to the source files.

### Additional Information

- part of #471
