### PR TITLE
style: enable linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,62 @@
-# linters-settings: This section is used to configure individual linters.
-linters-settings:
-  # gofmt: Configuration for the gofmt linter.
-  gofmt:
-    # simplify: Simplify code when possible.
-    simplify: true
-  # misspell: Configuration for the misspell linter.
-  misspell:
-    # locale: Set the locale to US to catch US-specific spelling mistakes.
-    locale: US
-
-# run: This section is used to configure how golangci-lint runs.
+---
 run:
   # timeout: Set a timeout of 5 minutes.
   timeout: 5m
-  # skip-dirs: Skip the specified directories.
-  skip-dirs:
-    - vendor
 
-# issues: This section is used to configure how golangci-lint handles issues.
+linters:
+  enable:
+    - dogsled
+    - exportloopref
+    - godot
+    - gofmt
+    # - revive
+    # - gosec
+    - govet
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - staticcheck
+    - unconvert
+    - whitespace
+
+linters-settings:
+  # Recommended settings from https://github.com/mgechev/revive#recommended-configuration.
+  revive:
+    ignoreGeneratedHeader: false
+    severity: "warning"
+    confidence: 0.8
+    errorCode: 0
+    warningCode: 0
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
 issues:
-  # exclude-rules: Exclude the specified rules.
   exclude-rules:
-    # Each rule is a dictionary with a linters list and a text string.
     - linters:
-        # linters: The rule applies to these linters.
         - staticcheck
       # text: Ignore using a deprecated function, variable, constant or field.
       text: "SA1019"

--- a/common/countries/countries.go
+++ b/common/countries/countries.go
@@ -22,7 +22,7 @@ func FindAlpha2ByName(
 
 	var countryNames map[string][]string
 
-	err = json.Unmarshal([]byte(countries), &countryNames)
+	err = json.Unmarshal(countries, &countryNames)
 
 	if err != nil {
 		return "undefined", err

--- a/common/elastic/client.go
+++ b/common/elastic/client.go
@@ -19,13 +19,13 @@ func (c *esClient) setClient(client *elastic.Client) {
 
 func (c *esClient) CreateMappings(indices []Index) error {
 	for _, index := range indices {
-		exists, err := c.client.IndexExists(string(index.Name)).
+		exists, err := c.client.IndexExists(index.Name).
 			Do(context.Background())
 		if err != nil {
 			return err
 		}
 		if !exists {
-			createIndex, err := c.client.CreateIndex(string(index.Name)).
+			createIndex, err := c.client.CreateIndex(index.Name).
 				BodyString(index.Body).
 				Do(context.Background())
 			if err != nil {

--- a/common/validatenode/validatenode.go
+++ b/common/validatenode/validatenode.go
@@ -12,10 +12,10 @@ func parseValidateError(
 	schema string,
 	resultErrors []gojsonschema.ResultError,
 ) ([]string, []string, [][]string) {
-	var (
-		failedTitles, failedDetails []string
-		failedSources               [][]string
-	)
+	failedTitles := make([]string, 0, len(resultErrors))
+	failedDetails := make([]string, 0, len(resultErrors))
+	failedSources := make([][]string, 0, len(resultErrors))
+
 	for _, desc := range resultErrors {
 		// title
 		failedType := desc.Type()

--- a/services/cronjob/schemaparser/internal/service/schema_service.go
+++ b/services/cronjob/schemaparser/internal/service/schema_service.go
@@ -199,7 +199,7 @@ func (s *schemaService) getSchema(
 	return &data, parsedFullData, nil
 }
 
-// Direct generate the bson.D type for saving to MongoDB
+// Direct generate the bson.D type for saving to MongoDB.
 func (s *schemaService) parseProperties(
 	fullData orderedmap.OrderedMap,
 	fieldListMap map[string]string,

--- a/services/dataproxy/cmd/seeder/main.go
+++ b/services/dataproxy/cmd/seeder/main.go
@@ -20,9 +20,10 @@ import (
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/dataproxy/config"
 )
 
-// global variables
-var fileName = "schema.xlsx"
-var sheetName = "sheet1"
+const (
+	fileName  = "schema.xlsx"
+	sheetName = "sheet1"
+)
 
 func Init() {
 	config.Init()

--- a/services/dataproxy/cmd/ukseeder/main.go
+++ b/services/dataproxy/cmd/ukseeder/main.go
@@ -18,9 +18,10 @@ import (
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/dataproxy/config"
 )
 
-// global variables
-var fileName = "co-ops-uk-data_2021_q3-tidied.xlsx"
-var sheetName = "open_data_organisations_2021_q3"
+const (
+	fileName  = "co-ops-uk-data_2021_q3-tidied.xlsx"
+	sheetName = "open_data_organisations_2021_q3"
+)
 
 func Init() {
 	config.Init()

--- a/services/dataproxy/internal/usecase/batch_usecase.go
+++ b/services/dataproxy/internal/usecase/batch_usecase.go
@@ -437,7 +437,7 @@ func (s *batchUsecase) Delete(userId string, batchId string) error {
 	return nil
 }
 
-// Convert csv to one-to-one map[string]string
+// Convert csv to one-to-one map[string]string.
 func csvToMap(records [][]string) []map[string]string {
 	csvHeader := records[0]
 	var rawProfiles []map[string]string
@@ -454,7 +454,7 @@ func csvToMap(records [][]string) []map[string]string {
 	return rawProfiles
 }
 
-// Convert one-to-one map[string]string to profile data structure
+// Convert one-to-one map[string]string to profile data structure.
 func mapToProfile(
 	rawProfile map[string]string,
 	schemas []string,
@@ -497,7 +497,7 @@ func mapToProfile(
 	return profile, nil
 }
 
-// Destructure field name and save field value to profile data structure
+// Destructure field name and save field value to profile data structure.
 func destructField(
 	profile map[string]interface{},
 	field string,


### PR DESCRIPTION
The following linters will be enabled as part of this PR:

- Dogsled: This linter detects unused code and suggests its removal, promoting a cleaner codebase.
- Exportloopref: This linter identifies cases where a loop variable is used in a deferred closure, preventing potential bugs.
- Godot: Specifically designed for the Godot game engine, this linter helps identify and address common pitfalls and errors.
- Gofmt: Gofmt is a tool for formatting Go code, ensuring consistent and readable code formatting throughout the project.
- Govet: Govet is a Go vet tool that analyzes Go code and reports suspicious constructs, such as potential bugs or suboptimal code.
- Misspell: This linter catches common spelling mistakes in code comments and strings, helping to improve code clarity.
- Nakedret: Nakedret detects naked returns (i.e., return statements without explicit arguments), promoting explicitness and reducing potential confusion.
- Nolintlint: Nolintlint allows custom linting directives to be applied selectively, suppressing specific linter warnings when necessary.
- Prealloc: Prealloc suggests using the built-in make() function instead of initializing slices and maps with a literal, which can improve performance.
- Staticcheck: Staticcheck is a linter that performs various static analysis checks to identify potential bugs, inefficiencies, and code smells.
- Unconvert: Unconvert detects unnecessary type conversions in Go code, helping to simplify and clarify the codebase.
- Whitespace: This linter highlights inconsistencies in whitespace usage, enforcing consistent indentation and spacing for improved readability.
