### PR TITLE
docs: add READMEs to /.github, /build and /cmd directories

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,85 @@
+# `/.github`
+
+## GitHub Workflows
+
+GitHub Workflows is a feature of GitHub Actions that automates tasks and
+workflows in a repository. A workflow is defined in a YAML file in the
+[.github/workflows directory](/.github/workflows) of a repository and can be
+triggered by events such as pushes, pull requests or scheduled intervals.
+Workflows run on GitHub-hosted virtual machines or on self-hosted runners.
+MurmurationsServices uses Workflows to build, test and deploy code.
+
+### `pull_request.yaml`
+
+This workflow defines two jobs that run tests and linting for the project when a
+pull request is opened or updated on the main branch. Automatically running
+tests and linting on every pull request helps ensure that the code is high
+quality and free of errors.
+
+### `main.yaml`
+
+This workflow is triggered by a push event on the `main` branch and automates
+the build, test and deployment process for the project's components. The
+workflow uses `make` commands to build and publish Docker images for each
+component and deploys the components to a Kubernetes cluster on DigitalOcean.
+
+The `test` job executes unit tests for the project and consists of three steps.
+The first step uses the `actions/checkout` action to check out the code for the
+project. The second step uses the `actions/setup-go` action to set up the Go
+environment with version 1.19.5. The third step runs the `make test` command,
+which is defined in the project's `Makefile` and runs the tests for the project.
+
+This `build-*` jobs build and publish Docker images for different components of
+the project. Each job runs on an `ubuntu-latest` runner and has three steps. The
+first step uses the `actions/checkout` action to check out the code for the
+project. The second step uses the `docker/login-action` action to log in to
+DockerHub using the `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN`
+secrets. The third step runs a `make` command to build and publish the Docker
+image for the component.
+
+The `deploy` job automates the deployment process for the project's components.
+The job is triggered by the completion of several other jobs, which are
+specified using the `needs` key. The job runs on an `ubuntu-latest` runner and
+deploys various components of the project to a Kubernetes cluster on
+DigitalOcean.
+
+The job consists of several steps that use the `make` command to restart the
+deployments for each component. The first step uses the `actions/checkout`
+action to check out the code for the project. The second step installs `doctl`,
+a command-line tool for managing DigitalOcean resources, and saves the
+`kubeconfig` for the Kubernetes cluster with short-lived credentials. The
+remaining steps restart the deployments for each component using the make
+`deploy-<component>` command.
+
+The `e2e-test` job is disabled because the end-to-end tests reference test
+schemas not contained in the production library.
+
+### `test.yaml`
+
+This workflow is exactly the same as the one above for the `test`, `build-*` and
+`deploy` jobs except that the deployment is made to a test environment, not the
+production one.
+
+The `e2e-test` job automates the end-to-end testing process for the project's
+components. The job is triggered by the completion of the `deploy` job, and uses
+the `newman` tool to execute the end-to-end tests and a custom shell script to
+check the availability of the endpoints.
+
+
+## Dependabot
+
+This is a `dependabot.yml` file that specifies the update schedule for two
+package ecosystems: `gomod` and `github-actions`. The `updates` key contains a
+list of dictionaries, where each dictionary specifies the package ecosystem, the
+directory to update, and the update schedule. In this case, both ecosystems are
+set to update daily, and the root directory is specified with the forward slash.
+
+The `gomod` package ecosystem is used for Go modules, which are a way to manage
+dependencies in Go projects. Dependabot is a tool that automates dependency
+updates, so this file is telling Dependabot to check for updates to Go modules
+and GitHub Actions on a daily basis.
+
+Overall, this file is a configuration file that helps automate the process of
+keeping dependencies up to date. By specifying the package ecosystems and update
+schedule, Dependabot can automatically check for updates and create pull
+requests to update the dependencies in the project.

--- a/build/README.md
+++ b/build/README.md
@@ -12,7 +12,7 @@ image for a service. By running `make docker-build-<service_name>`, the command
 specified in the target will be executed, resulting in a Docker image that can
 be used to deploy the service.
 
-## `<service_name>/package/Dockerfile-dev`
+## `<service_name>/docker/Dockerfile-dev`
 
 This is a Dockerfile that defines a development environment for a service. 
 
@@ -48,7 +48,7 @@ this case, it runs `reflex` with the configuration file located at
 `/build/<service_name>/reflex.conf`. This will start the application using
 `reflex` for hot reloading when the Docker container is run.
 
-## `<service_name>/package/Dockerfile-prod`
+## `<service_name>/docker/Dockerfile-prod`
 
 This is a Dockerfile that defines a production environment for a service. 
 

--- a/build/README.md
+++ b/build/README.md
@@ -45,8 +45,8 @@ application. The `go install` command installs reflex from the
 
 The `CMD` command specifies the command to run when the container starts. In
 this case, it runs `reflex` with the configuration file located at
-[/build/library/reflex.conf](/build/library/reflex.conf). This will start the
-application using `reflex` for hot reloading when the Docker container is run.
+`/build/<service_name>/reflex.conf`. This will start the application using
+`reflex` for hot reloading when the Docker container is run.
 
 ## `<service_name>/package/Dockerfile-prod`
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,71 @@
+# `/build/`
+
+## `<service_name>/mk/Makefile`
+
+This `Makefile` file defines a target called `docker-build-<service_name>` that
+specifies a command to build a Docker image for a service. The command is
+executed by running `docker build` with the `-f` flag to specify the Dockerfile
+to use, and the `-t` flag to specify the name and tag for the resulting image.
+
+The purpose of a Makefile target is to automate the process of building a Docker
+image for a service. By running `make docker-build-<service_name>`, the command
+specified in the target will be executed, resulting in a Docker image that can
+be used to deploy the service.
+
+## `<service_name>/package/Dockerfile-dev`
+
+This is a Dockerfile that defines a development environment for a service. 
+
+The `FROM` command specifies the base image to use, which in this case is
+`golang:1.19.5-alpine`. Alpine is a lightweight Linux distribution, which makes
+it a good choice for Docker images. The `golang:1.19.5-alpine` image is an image
+that contains the Go programming language.
+
+The `RUN` command updates the package index inside the container using the `apk`
+package manager, which is similar to `apt-get` on Ubuntu.
+
+The `WORKDIR` command sets the working directory inside the container to
+`/src/<service_name>`. This is where the application code will be copied to.
+
+The `COPY` command copies the `go.mod` and `go.sum` files to the working
+directory. The `go.mod` file contains the dependencies for the application and
+the `go.sum` file contains the checksums for the dependencies.
+
+The `RUN` command then downloads the dependencies specified in the `go.mod` file
+using `go mod download`. This command is run before copying the application code
+to take advantage of Docker's caching mechanism. If the `go.mod` file hasn't
+changed, then the dependencies don't need to be downloaded again, speeding up
+the build process.
+
+The next `RUN` command installs the latest version of `reflex`, which is a tool
+for hot reloading Go applications. Hot reloading allows developers to see
+changes to their code immediately without having to manually restart the
+application. The `go install` command installs reflex from the
+[github.com/cespare/reflex](https://github.com/cespare/reflex) repository.
+
+The `CMD` command specifies the command to run when the container starts. In
+this case, it runs `reflex` with the configuration file located at
+[/build/library/reflex.conf](/build/library/reflex.conf). This will start the
+application using `reflex` for hot reloading when the Docker container is run.
+
+## `<service_name>/package/Dockerfile-prod`
+
+This is a Dockerfile that defines a production environment for a service. 
+
+The build stage compiles the Go app and creates a fully static binary, which is
+then copied to the runtime stage. The runtime stage sets up the environment for
+running the app and copies the static binary and files to the appropriate
+locations. By using a Docker image, the app can be easily deployed to different
+environments without worrying about dependencies or configuration.
+
+## `<service_name>/reflex.conf`
+
+The `reflex.conf` file is used with the reflex tool, which is a command-line
+tool for running commands when files change. The `-r` flag specifies a regular
+expression to match files, and the `-R` flag specifies a regular expression to
+exclude files. In this case, the regular expression `-R '_test\.go$'` excludes
+files with a `_test.go` suffix.
+
+When a file with a `.go` extension is modified, the `go run ./cmd/library`
+command is executed. This command compiles and runs the library service in the
+cmd directory of the project.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,30 @@
+# `/cmd/`
+
+## `<service_name>/main.go`
+
+This is a Go program that defines the `main` package for a service. In Go, the
+`main` package is a special package that defines the entry point of an
+executable program. The `main` package must have a `main` function defined,
+which is the first function that gets executed when the program is run. The
+`main` function can call other functions and packages to perform the desired
+functionality of the program.
+
+The import statements import two packages: `logger` and the named service. The
+`logger` package is used for logging messages, while the other contains the
+implementation of the named service.
+
+The `main` function by logging a message to indicate that the service is
+starting up.
+
+It then creates a new instance of the `<service_name>.Service` struct using the
+`<service_name>.NewService` function. This function initializes the service and
+returns a pointer to the `Service` struct.
+
+It then starts a new goroutine that waits for the service to start up using the
+`WaitUntilUp` method of the `Service` struct. This method returns a channel that
+is closed when the service is up and running. The goroutine waits for the
+channel to be closed and then logs a message to indicate that the service has
+started.
+
+Finally, it calls the `Run` method of the `Service` struct to start the service.
+This method blocks until the service is shut down.


### PR DESCRIPTION
Part of #459 

Regarding the `/cmd/README.md`, it is more detailed than for what we will write for the rest of the codebase, but the aim is to make it easy for Go newbies to understand how Go programs are launched.

Ditto for those unfamiliar with GitHub Actions/Workflows and Docker.
