### PR TITLE
fix: handle missing GitHub token, log when no new commits

### DIFF
--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -79,10 +79,11 @@ func GetByteWithBearerToken(url string, token string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
+	if resp.StatusCode != http.StatusOK {
 		return []byte{}, fmt.Errorf(
-			"error the requested URL %s returned 404 not found",
+			"error the requested URL %s returned %d status code",
 			url,
+			resp.StatusCode,
 		)
 	}
 

--- a/services/cronjob/schemaparser/pkg/schemaparser/cronjob.go
+++ b/services/cronjob/schemaparser/pkg/schemaparser/cronjob.go
@@ -57,6 +57,9 @@ func (sc *SchemaCron) Run() {
 
 	// If there's no new commit, there's nothing to do.
 	if !hasNewCommit {
+		logger.Info(
+			"No new commit found. Latest commit on GitHub: " + branchInfo.Commit.InnerCommit.Author.Date,
+		)
 		return
 	}
 


### PR DESCRIPTION
Resolved #486 

We implemented a 'required' feature in our service to ensure the presence of a valid token. To enhance this functionality, I made some modifications to the 'httputil.go' file. Previously, it only handled 404 errors, but now it also handles all other errors than 200, such as 401 errors for invalid tokens. By receiving a 401 response, we can identify if the token provided is incorrect.

Additionally, I included an information log in case there are no new commits. To ensure that we receive accurate information from GitHub, I added 'branchInfo.Commit.InnerCommit.Author.Date' to the log.