### PR TITLE
config: Prioritize database pods

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -195,6 +195,9 @@ jobs:
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 murmprod
 
+      - name: Deploy Murmurations Core
+        run: make deploy-murmurations-core DEPLOY_ENV=production
+
       - name: Restart index deployment
         run: make deploy-index DEPLOY_ENV=production
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,6 +195,9 @@ jobs:
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 murmtest
 
+      - name: Deploy Murmurations Core
+        run: make deploy-murmurations-core DEPLOY_ENV=staging
+
       - name: Restart index deployment
         run: make deploy-index DEPLOY_ENV=staging
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 #--------------------------
 .PHONY: dev
 dev:
-	export SOURCEPATH=$(PWD) && skaffold dev --port-forward
+	export SOURCEPATH=$(PWD) && skaffold dev --tolerate-failures-until-deadline=true --port-forward
 
 #--------------------------
 # Runs the unit tests.
@@ -139,6 +139,9 @@ docker-push-dataproxyrefresher: docker-tag-dataproxyrefresher
 
 # ---------------------------------------------------------------
 
+deploy-murmurations-core:
+	helm upgrade murmurations-core ./charts/murmurations/charts/core --set global.env=$(DEPLOY_ENV) --install --atomic
+
 deploy-ingress:
 	helm upgrade murmurations-ingress ./charts/murmurations/charts/ingress --set global.env=$(DEPLOY_ENV) --install --atomic
 
@@ -180,6 +183,9 @@ deploy-dataproxyrefresher:
 # Please update to the version you want to deploy.
 SPECIFIC_TAG ?= <>
 ENV ?= <>
+
+manually-deploy-murmurations-core:
+	helm upgrade murmurations-core ./charts/murmurations/charts/core --set global.env=$(ENV) --install --atomic
 
 manually-deploy-ingress:
 	helm upgrade murmurations-ingress ./charts/murmurations/charts/ingress --set global.env=$(ENV) --install --atomic

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ endif
 #--------------------------
 .PHONY: dev
 dev:
+    # There's no particular deployment order for Helm, so we use --tolerate-failures-until-deadline to
+    # prevent deployment failure if the required object, such as PriorityClass, has not been deployed yet.
 	export SOURCEPATH=$(PWD) && skaffold dev --tolerate-failures-until-deadline=true --port-forward
 
 #--------------------------

--- a/charts/murmurations/charts/core/Chart.yaml
+++ b/charts/murmurations/charts/core/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: core
+description: murmurations core
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.5
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.5

--- a/charts/murmurations/charts/core/templates/priorityclass.yaml
+++ b/charts/murmurations/charts/core/templates/priorityclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: murmurations-high-priority
+  # Ensure that the PriorityClass is created before other resources in the core chart.
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-5"
+# The value 1000 is relative. It can range from -2147483648 to 2147483647. By default, all pods are set to 0.
+value: 1000
+globalDefault: false
+description: "Use this priority class for high-priority pods."

--- a/charts/murmurations/charts/index/templates/es/dpl.yaml
+++ b/charts/murmurations/charts/index/templates/es/dpl.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: index-es
     spec:
+      priorityClassName: murmurations-high-priority
       containers:
         - name: index-es
           image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5

--- a/charts/murmurations/charts/index/templates/mongo/dpl.yaml
+++ b/charts/murmurations/charts/index/templates/mongo/dpl.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: index-mongo
     spec:
+      priorityClassName: murmurations-high-priority
       containers:
         - name: index-mongo
           image: mongo:5.0.6

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -45,6 +45,8 @@ build:
       docker:
         dockerfile: build/validation/docker/Dockerfile-dev
 deploy:
+  # Deadline for deployments to stabilize in seconds.
+  statusCheckDeadlineSeconds: 300
   helm:
     releases:
     - name: development


### PR DESCRIPTION
Part of #552 

- [x] Follow the [doc](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to update priority of pods
          - PriorityClass is used to set the scheduling priorities of pods, influencing which pods are evicted or scheduled first when cluster resources are limited.
- [x] Update Makefile

---

part of #552 