### PR TITLE
feat: Add size limits to fields stored in Index

### DIFF
--- a/pkg/schemavalidator/builder.go
+++ b/pkg/schemavalidator/builder.go
@@ -62,5 +62,22 @@ func (b *Builder) Build() (*SchemaValidator, error) {
 		return nil, fmt.Errorf("a data loader must be provided")
 	}
 
+	profileData, err := b.schemaValidator.ProfileLoader.Load().LoadJSON()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to load JSON from the profile URL: %w",
+			err,
+		)
+	}
+
+	jsonMap, ok := profileData.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf(
+			"invalid JSON format: expected a map[string]interface{}",
+		)
+	}
+
+	b.schemaValidator.JSON = jsonMap
+
 	return b.schemaValidator, nil
 }

--- a/pkg/schemavalidator/builder.go
+++ b/pkg/schemavalidator/builder.go
@@ -49,6 +49,12 @@ func (b *Builder) WithMapProfile(
 	return b
 }
 
+// WithCustomValidation enables to custom validation.
+func (b *Builder) WithCustomValidation() *Builder {
+	b.schemaValidator.CustomValidation = true
+	return b
+}
+
 // Build validates the builder state and returns the built SchemaValidator.
 func (b *Builder) Build() (*SchemaValidator, error) {
 	// Check that required fields are set.

--- a/pkg/schemavalidator/cutomvalidator.go
+++ b/pkg/schemavalidator/cutomvalidator.go
@@ -105,11 +105,29 @@ func validateLatLon(geoValue map[string]interface{}, vr *ValidationResult) {
 		}
 	}
 
+	// Validate latitude if exists.
 	if lat, exists := geoValue["lat"]; exists {
 		validateCoordinate(lat, "Latitude", -90, 90)
 	}
+
+	// Validate longitude if exists.
 	if lon, exists := geoValue["lon"]; exists {
 		validateCoordinate(lon, "Longitude", -180, 180)
+	}
+
+	// Check for extra keys
+	for key := range geoValue {
+		if key != "lat" && key != "lon" {
+			vr.AppendError(
+				"Extra Field in Geolocation",
+				fmt.Sprintf(
+					"Extra field '%s' found in Geolocation object",
+					key,
+				),
+				[]string{"pointer", "/geolocation/" + key},
+				http.StatusBadRequest,
+			)
+		}
 	}
 }
 

--- a/pkg/schemavalidator/cutomvalidator.go
+++ b/pkg/schemavalidator/cutomvalidator.go
@@ -6,12 +6,16 @@ import (
 	"net/http"
 )
 
+// CustomValidator defines the interface for custom validation.
 type CustomValidator interface {
+	// Validate performs custom validation.
 	Validate(value interface{}) *ValidationResult
 }
 
+// GeolocationValidator validates geolocation data.
 type GeolocationValidator struct{}
 
+// Validate checks the validity of geolocation data.
 func (v *GeolocationValidator) Validate(value interface{}) *ValidationResult {
 	vr := NewValidationResult()
 	if geoValue, ok := value.(map[string]interface{}); ok {
@@ -80,10 +84,12 @@ func (v *GeolocationValidator) Validate(value interface{}) *ValidationResult {
 	return vr
 }
 
+// StringValidator validates string data with a maximum length constraint.
 type StringValidator struct {
 	MaxLength int
 }
 
+// Validate checks if the given string exceeds the maximum length.
 func (v *StringValidator) Validate(value interface{}) *ValidationResult {
 	vr := NewValidationResult()
 	if strValue, ok := value.(string); ok {
@@ -101,8 +107,10 @@ func (v *StringValidator) Validate(value interface{}) *ValidationResult {
 	return vr
 }
 
+// TagsValidator validates an array of tags.
 type TagsValidator struct{}
 
+// Validate checks the validity of an array of tags.
 func (v *TagsValidator) Validate(value interface{}) *ValidationResult {
 	vr := NewValidationResult()
 	if tags, ok := value.([]interface{}); ok {

--- a/pkg/schemavalidator/cutomvalidator.go
+++ b/pkg/schemavalidator/cutomvalidator.go
@@ -40,7 +40,7 @@ func (v *GeolocationValidator) Validate(value interface{}) *ValidationResult {
 			} else {
 				vr.AppendError(
 					"Invalid Latitude Type",
-					"Latitude should be a json.Number",
+					"Latitude should be a number",
 					[]string{"pointer", "/geolocation/lat"},
 					http.StatusBadRequest,
 				)
@@ -67,7 +67,7 @@ func (v *GeolocationValidator) Validate(value interface{}) *ValidationResult {
 			} else {
 				vr.AppendError(
 					"Invalid Longitude Type",
-					"Longitude should be a json.Number",
+					"Longitude should be a number",
 					[]string{"pointer", "/geolocation/lon"},
 					http.StatusBadRequest,
 				)

--- a/pkg/schemavalidator/cutomvalidator.go
+++ b/pkg/schemavalidator/cutomvalidator.go
@@ -1,0 +1,145 @@
+package schemavalidator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type CustomValidator interface {
+	Validate(value interface{}) *ValidationResult
+}
+
+type GeolocationValidator struct{}
+
+func (v *GeolocationValidator) Validate(value interface{}) *ValidationResult {
+	vr := NewValidationResult()
+	if geoValue, ok := value.(map[string]interface{}); ok {
+		if lat, exists := geoValue["lat"]; exists {
+			if latValue, ok := lat.(json.Number); ok {
+				f, err := latValue.Float64()
+				if err != nil {
+					vr.AppendError(
+						"Invalid Latitude Type",
+						"Latitude should be a number",
+						[]string{"pointer", "/geolocation/lat"},
+						http.StatusBadRequest,
+					)
+				} else if f < -90 || f > 90 {
+					vr.AppendError(
+						"Invalid Latitude",
+						"Latitude should be between -90 and 90",
+						[]string{"pointer", "/geolocation/lat"},
+						http.StatusBadRequest,
+					)
+				}
+			} else {
+				vr.AppendError(
+					"Invalid Latitude Type",
+					"Latitude should be a json.Number",
+					[]string{"pointer", "/geolocation/lat"},
+					http.StatusBadRequest,
+				)
+			}
+		}
+		if lon, exists := geoValue["lon"]; exists {
+			if lonValue, ok := lon.(json.Number); ok {
+				f, err := lonValue.Float64()
+				if err != nil {
+					vr.AppendError(
+						"Invalid Longitude Type",
+						"Longitude should be a number",
+						[]string{"pointer", "/geolocation/lon"},
+						http.StatusBadRequest,
+					)
+				} else if f < -180 || f > 180 {
+					vr.AppendError(
+						"Invalid Longitude",
+						"Longitude should be between -180 and 180",
+						[]string{"pointer", "/geolocation/lon"},
+						http.StatusBadRequest,
+					)
+				}
+			} else {
+				vr.AppendError(
+					"Invalid Longitude Type",
+					"Longitude should be a json.Number",
+					[]string{"pointer", "/geolocation/lon"},
+					http.StatusBadRequest,
+				)
+			}
+		}
+	} else {
+		vr.AppendError(
+			"Invalid Geolocation Type",
+			"Geolocation should be an object",
+			[]string{"pointer", "/geolocation"},
+			http.StatusBadRequest,
+		)
+	}
+	return vr
+}
+
+type StringValidator struct {
+	MaxLength int
+}
+
+func (v *StringValidator) Validate(value interface{}) *ValidationResult {
+	vr := NewValidationResult()
+	if strValue, ok := value.(string); ok {
+		if len(strValue) > v.MaxLength {
+			vr.AppendError(
+				fmt.Sprintf("Invalid Length, max length is %d", v.MaxLength),
+				"String length exceeded",
+				nil,
+				http.StatusBadRequest,
+			)
+		}
+	} else {
+		vr.AppendError("Invalid Type", "Should be a string", nil, http.StatusBadRequest)
+	}
+	return vr
+}
+
+type TagsValidator struct{}
+
+func (v *TagsValidator) Validate(value interface{}) *ValidationResult {
+	vr := NewValidationResult()
+	if tags, ok := value.([]interface{}); ok {
+		if len(tags) > 100 {
+			vr.AppendError(
+				"Too Many Tags",
+				"Maximum of 100 tags allowed",
+				nil,
+				http.StatusBadRequest,
+			)
+		}
+		for _, tag := range tags {
+			if tagStr, ok := tag.(string); ok {
+				if len(tagStr) > 100 {
+					vr.AppendError(
+						"Tag Too Long",
+						"Each tag should be under 100 characters",
+						nil,
+						http.StatusBadRequest,
+					)
+				}
+			} else {
+				vr.AppendError(
+					"Invalid Tag Type",
+					"Tags should be strings",
+					nil,
+					http.StatusBadRequest,
+				)
+			}
+		}
+	} else {
+		vr.AppendError(
+			"Invalid Tags Type",
+			"Tags should be an array of strings",
+			nil,
+			http.StatusBadRequest,
+		)
+	}
+	return vr
+}

--- a/pkg/schemavalidator/schemavalidator.go
+++ b/pkg/schemavalidator/schemavalidator.go
@@ -86,69 +86,89 @@ type SchemaValidator struct {
 	SchemaLoader Loader
 	// The loader that fetches the profile data.
 	ProfileLoader ProfileLoader
+	// The JSON data.
+	JSON map[string]interface{}
 }
 
 // Validate validates the data against the schemas and returns the validation result.
 func (v *SchemaValidator) Validate() *ValidationResult {
-	var (
-		errorMessages []string
-		details       []string
-		sources       [][]string
-		errorStatus   []int
-	)
+	finalResult := NewValidationResult()
 
 	for _, schemaStr := range v.Schemas {
 		schema, err := v.SchemaLoader.Load(schemaStr)
 		if err != nil {
-			errorMessages = append(errorMessages, "Error loading schema")
-			details = append(
-				details,
-				fmt.Sprintf(
-					"Error loading schema (%s): %v",
-					schemaStr,
-					err,
-				),
+			finalResult.AppendError(
+				"Error loading schema",
+				fmt.Sprintf("Error loading schema (%s): %v", schemaStr, err),
+				[]string{"pointer", "/linked_schemas"},
+				http.StatusNotFound,
 			)
-			sources = append(sources, []string{"pointer", "/linked_schemas"})
-			errorStatus = append(errorStatus, http.StatusNotFound)
 			continue
 		}
 
-		result, err := schema.Validate(v.ProfileLoader.Load())
+		validationResult, err := schema.Validate(v.ProfileLoader.Load())
 		if err != nil {
-			errorMessages = append(errorMessages, "Cannot Validate Document")
-			details = append(
-				details,
+			finalResult.AppendError(
+				"Cannot Validate Document",
 				fmt.Sprintf(
 					"Error when trying to validate document: %s",
 					err.Error(),
 				),
+				nil,
+				http.StatusBadRequest,
 			)
-			errorStatus = append(errorStatus, http.StatusBadRequest)
 			continue
 		}
 
-		if !result.Valid() {
+		if !validationResult.Valid() {
 			failedTitles, failedDetails, failedSources := parseValidateError(
 				schemaStr,
-				result.Errors(),
+				validationResult.Errors(),
 			)
-			errorMessages = append(errorMessages, failedTitles...)
-			details = append(details, failedDetails...)
-			sources = append(sources, failedSources...)
-			for i := 0; i < len(failedTitles); i++ {
-				errorStatus = append(errorStatus, http.StatusBadRequest)
+			statusCodes := make([]int, len(failedTitles))
+			for i := range statusCodes {
+				// Populate it with the same status code for each error.
+				statusCodes[i] = http.StatusBadRequest
+			}
+			finalResult.AppendErrors(
+				failedTitles,
+				failedDetails,
+				failedSources,
+				statusCodes,
+			)
+		}
+	}
+
+	// Custom validation logic.
+	finalResult.Merge(v.CustomValidate())
+
+	return finalResult
+}
+
+// CustomValidate performs custom validation on the JSON data.
+func (v *SchemaValidator) CustomValidate() *ValidationResult {
+	finalResult := NewValidationResult()
+
+	validators := map[string]CustomValidator{
+		"geolocation": &GeolocationValidator{},
+		"name":        &StringValidator{MaxLength: 200},
+		"locality":    &StringValidator{MaxLength: 100},
+		"region":      &StringValidator{MaxLength: 100},
+		"country":     &StringValidator{MaxLength: 3},
+		"primary_url": &StringValidator{MaxLength: 2000},
+		"tags":        &TagsValidator{},
+	}
+
+	for field, validator := range validators {
+		if value, exists := v.JSON[field]; exists {
+			result := validator.Validate(value)
+			if !result.Valid {
+				finalResult.Merge(result)
 			}
 		}
 	}
 
-	return &ValidationResult{
-		Valid:         len(errorMessages) == 0,
-		ErrorMessages: errorMessages,
-		Details:       details,
-		Sources:       sources,
-		ErrorStatus:   errorStatus,
-	}
+	return finalResult
 }
 
 // getSchemaURL constructs the full schema URL and returns it.

--- a/pkg/schemavalidator/schemavalidator.go
+++ b/pkg/schemavalidator/schemavalidator.go
@@ -139,7 +139,6 @@ func (v *SchemaValidator) Validate() *ValidationResult {
 		}
 	}
 
-	// Custom validation logic.
 	finalResult.Merge(v.CustomValidate())
 
 	return finalResult
@@ -150,13 +149,14 @@ func (v *SchemaValidator) CustomValidate() *ValidationResult {
 	finalResult := NewValidationResult()
 
 	validators := map[string]CustomValidator{
-		"geolocation": &GeolocationValidator{},
-		"name":        &StringValidator{MaxLength: 200},
-		"locality":    &StringValidator{MaxLength: 100},
-		"region":      &StringValidator{MaxLength: 100},
-		"country":     &StringValidator{MaxLength: 3},
-		"primary_url": &StringValidator{MaxLength: 2000},
-		"tags":        &TagsValidator{},
+		"geolocation":      &GeolocationValidator{},
+		"name":             &StringValidator{MaxLength: 200},
+		"locality":         &StringValidator{MaxLength: 100},
+		"region":           &StringValidator{MaxLength: 100},
+		"country_name":     &StringValidator{MaxLength: 100},
+		"country_iso_3166": &StringValidator{MaxLength: 3},
+		"primary_url":      &StringValidator{MaxLength: 2000},
+		"tags":             &TagsValidator{},
 	}
 
 	for field, validator := range validators {

--- a/pkg/schemavalidator/schemavalidator.go
+++ b/pkg/schemavalidator/schemavalidator.go
@@ -88,6 +88,8 @@ type SchemaValidator struct {
 	ProfileLoader ProfileLoader
 	// The JSON data.
 	JSON map[string]interface{}
+	// Enable/disable custom validation.
+	CustomValidation bool
 }
 
 // Validate validates the data against the schemas and returns the validation result.
@@ -139,8 +141,11 @@ func (v *SchemaValidator) Validate() *ValidationResult {
 		}
 	}
 
-	finalResult.Merge(v.CustomValidate())
-
+	if !finalResult.Valid {
+		return finalResult
+	} else if v.CustomValidation {
+		return finalResult.Merge(v.CustomValidate())
+	}
 	return finalResult
 }
 

--- a/pkg/schemavalidator/schemavalidator_test.go
+++ b/pkg/schemavalidator/schemavalidator_test.go
@@ -120,6 +120,7 @@ func TestValidate_CustomValidator(t *testing.T) {
 			validator, err := schemavalidator.NewBuilder().
 				WithStrSchemas([]string{StrSchema}).
 				WithStrProfile(tt.profile).
+				WithCustomValidation().
 				Build()
 
 			require.NoError(t, err)

--- a/pkg/schemavalidator/schemavalidator_test.go
+++ b/pkg/schemavalidator/schemavalidator_test.go
@@ -1,0 +1,150 @@
+package schemavalidator_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/schemavalidator"
+)
+
+var StrSchema = `{}`
+
+func TestValidate_CustomValidator(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		valid   bool
+		reason  string
+	}{
+		{
+			name:    "Valid Geolocation",
+			profile: `{"geolocation": {"lat": 50.123, "lon": -75.123}}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Latitude",
+			profile: `{"geolocation": {"lat": 100.123, "lon": -75.123}}`,
+			valid:   false,
+			reason:  "Latitude exceeds 90",
+		},
+		{
+			name:    "Invalid Longitude",
+			profile: `{"geolocation": {"lat": 50.123, "lon": -200.123}}`,
+			valid:   false,
+			reason:  "Longitude exceeds 180",
+		},
+		{
+			name:    "Valid Name",
+			profile: `{"name": "John Doe"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Name",
+			profile: fmt.Sprintf(`{"name": "%s"}`, randomString(201)),
+			valid:   false,
+			reason:  "Name length exceeds 200 characters",
+		},
+		{
+			name:    "Valid Locality",
+			profile: `{"locality": "New York"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Locality",
+			profile: fmt.Sprintf(`{"locality": "%s"}`, randomString(101)),
+			valid:   false,
+			reason:  "Locality length exceeds 100 characters",
+		},
+		{
+			name:    "Valid Country",
+			profile: `{"country": "USA"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Country",
+			profile: `{"country": "United States"}`,
+			valid:   false,
+			reason:  "Country length exceeds 3 characters",
+		},
+		{
+			name:    "Valid Tags",
+			profile: `{"tags": ["tag1", "tag2"]}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Tags",
+			profile: fmt.Sprintf(`{"tags": ["%s", "tag2"]}`, randomString(101)),
+			valid:   false,
+			reason:  "Tag length exceeds 100 characters",
+		},
+		{
+			name: "Invalid Number of Tags",
+			profile: fmt.Sprintf(
+				`{"tags": [%s]}`,
+				strings.Join(generateTags(101), ","),
+			),
+			valid:  false,
+			reason: "Number of tags exceeds 100",
+		},
+		{
+			name:    "Valid Primary URL",
+			profile: `{"primary_url": "https://example.com"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Primary URL",
+			profile: fmt.Sprintf(`{"primary_url": "%s"}`, randomURL(2001)),
+			valid:   false,
+			reason:  "Primary URL length exceeds 2000 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, err := schemavalidator.NewBuilder().
+				WithStrSchemas([]string{StrSchema}).
+				WithStrProfile(tt.profile).
+				Build()
+
+			require.NoError(t, err)
+			result := validator.Validate()
+			require.Equal(t, tt.valid, result.Valid)
+			if !tt.valid {
+				t.Log("Reason for failure:", tt.reason) // Log the reason here
+			}
+		})
+	}
+}
+
+func randomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	var b strings.Builder
+	for i := 0; i < length; i++ {
+		randomIndex := rand.Intn(len(charset))
+		b.WriteByte(charset[randomIndex])
+	}
+	return b.String()
+}
+
+func randomURL(length int) string {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "example.com",
+		// 18 is the length of "https://example.com".
+		Path: randomString(length - 18),
+	}
+	return u.String()
+}
+
+func generateTags(count int) []string {
+	tags := make([]string, count)
+	for i := 0; i < count; i++ {
+		tags[i] = fmt.Sprintf("\"tag%d\"", i+1)
+	}
+	return tags
+}

--- a/pkg/schemavalidator/schemavalidator_test.go
+++ b/pkg/schemavalidator/schemavalidator_test.go
@@ -39,6 +39,12 @@ func TestValidate_CustomValidator(t *testing.T) {
 			reason:  "Longitude exceeds 180",
 		},
 		{
+			name:    "Extra Fields in Geolocation",
+			profile: `{"geolocation": {"lat": 50.123, "lon": -75.123, "extraField": "invalid"}}`,
+			valid:   false,
+			reason:  "Extra field 'extraField' found in Geolocation object",
+		},
+		{
 			name:    "Valid Geolocation as String",
 			profile: `{"geolocation": "50.123,-75.123"}`,
 			valid:   true,

--- a/pkg/schemavalidator/schemavalidator_test.go
+++ b/pkg/schemavalidator/schemavalidator_test.go
@@ -61,15 +61,26 @@ func TestValidate_CustomValidator(t *testing.T) {
 			reason:  "Locality length exceeds 100 characters",
 		},
 		{
+			name:    "Valid Country Name",
+			profile: `{"country_name": "United States"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Country Name",
+			profile: fmt.Sprintf(`{"country_name": "%s"}`, randomString(101)),
+			valid:   false,
+			reason:  "Country name exceeds 100 characters",
+		},
+		{
 			name:    "Valid Country",
-			profile: `{"country": "USA"}`,
+			profile: `{"country_iso_3166": "USA"}`,
 			valid:   true,
 		},
 		{
 			name:    "Invalid Country",
-			profile: `{"country": "United States"}`,
+			profile: `{"country_iso_3166": "United States"}`,
 			valid:   false,
-			reason:  "Country length exceeds 3 characters",
+			reason:  "Country ISO code exceeds 3 characters",
 		},
 		{
 			name:    "Valid Tags",

--- a/pkg/schemavalidator/schemavalidator_test.go
+++ b/pkg/schemavalidator/schemavalidator_test.go
@@ -39,6 +39,23 @@ func TestValidate_CustomValidator(t *testing.T) {
 			reason:  "Longitude exceeds 180",
 		},
 		{
+			name:    "Valid Geolocation as String",
+			profile: `{"geolocation": "50.123,-75.123"}`,
+			valid:   true,
+		},
+		{
+			name:    "Invalid Geolocation as String",
+			profile: `{"geolocation": "100.123,-75.123"}`,
+			valid:   false,
+			reason:  "Latitude exceeds 90",
+		},
+		{
+			name:    "Invalid Geolocation Format",
+			profile: `{"geolocation": "50.123"}`,
+			valid:   false,
+			reason:  "Geolocation string should be in 'lat,lon' format",
+		},
+		{
 			name:    "Valid Name",
 			profile: `{"name": "John Doe"}`,
 			valid:   true,
@@ -126,9 +143,6 @@ func TestValidate_CustomValidator(t *testing.T) {
 			require.NoError(t, err)
 			result := validator.Validate()
 			require.Equal(t, tt.valid, result.Valid)
-			if !tt.valid {
-				t.Log("Reason for failure:", tt.reason) // Log the reason here
-			}
 		})
 	}
 }

--- a/pkg/schemavalidator/validationresult.go
+++ b/pkg/schemavalidator/validationresult.go
@@ -50,9 +50,9 @@ func (vr *ValidationResult) AppendErrors(
 }
 
 // Merge combines another ValidationResult into the current one.
-func (vr *ValidationResult) Merge(other *ValidationResult) {
+func (vr *ValidationResult) Merge(other *ValidationResult) *ValidationResult {
 	if other == nil || other.Valid {
-		return
+		return vr
 	}
 	vr.AppendErrors(
 		other.ErrorMessages,
@@ -60,4 +60,5 @@ func (vr *ValidationResult) Merge(other *ValidationResult) {
 		other.Sources,
 		other.ErrorStatus,
 	)
+	return vr
 }

--- a/pkg/schemavalidator/validationresult.go
+++ b/pkg/schemavalidator/validationresult.go
@@ -14,6 +14,7 @@ type ValidationResult struct {
 	ErrorStatus []int
 }
 
+// NewValidationResult initializes a new ValidationResult object with default values.
 func NewValidationResult() *ValidationResult {
 	return &ValidationResult{
 		Valid:         true,
@@ -24,6 +25,7 @@ func NewValidationResult() *ValidationResult {
 	}
 }
 
+// AppendError adds a single error to the ValidationResult.
 func (vr *ValidationResult) AppendError(
 	errorMessage, detail string,
 	source []string,
@@ -36,6 +38,7 @@ func (vr *ValidationResult) AppendError(
 	vr.Valid = false
 }
 
+// AppendErrors adds multiple errors to the ValidationResult.
 func (vr *ValidationResult) AppendErrors(
 	errorMessages, details []string,
 	sources [][]string,
@@ -46,6 +49,7 @@ func (vr *ValidationResult) AppendErrors(
 	}
 }
 
+// Merge combines another ValidationResult into the current one.
 func (vr *ValidationResult) Merge(other *ValidationResult) {
 	if other == nil || other.Valid {
 		return

--- a/pkg/schemavalidator/validationresult.go
+++ b/pkg/schemavalidator/validationresult.go
@@ -13,3 +13,47 @@ type ValidationResult struct {
 	// HTTP status codes associated with each error.
 	ErrorStatus []int
 }
+
+func NewValidationResult() *ValidationResult {
+	return &ValidationResult{
+		Valid:         true,
+		ErrorMessages: make([]string, 0),
+		Details:       make([]string, 0),
+		Sources:       make([][]string, 0),
+		ErrorStatus:   make([]int, 0),
+	}
+}
+
+func (vr *ValidationResult) AppendError(
+	errorMessage, detail string,
+	source []string,
+	status int,
+) {
+	vr.ErrorMessages = append(vr.ErrorMessages, errorMessage)
+	vr.Details = append(vr.Details, detail)
+	vr.Sources = append(vr.Sources, source)
+	vr.ErrorStatus = append(vr.ErrorStatus, status)
+	vr.Valid = false
+}
+
+func (vr *ValidationResult) AppendErrors(
+	errorMessages, details []string,
+	sources [][]string,
+	status []int,
+) {
+	for i := 0; i < len(errorMessages); i++ {
+		vr.AppendError(errorMessages[i], details[i], sources[i], status[i])
+	}
+}
+
+func (vr *ValidationResult) Merge(other *ValidationResult) {
+	if other == nil || other.Valid {
+		return
+	}
+	vr.AppendErrors(
+		other.ErrorMessages,
+		other.Details,
+		other.Sources,
+		other.ErrorStatus,
+	)
+}

--- a/services/dataproxy/internal/service/batch.go
+++ b/services/dataproxy/internal/service/batch.go
@@ -89,6 +89,7 @@ func (s *batchService) Validate(
 		validator, err := schemavalidator.NewBuilder().
 			WithStrSchemas(validateJSONSchemas).
 			WithMapProfile(profile).
+			WithCustomValidation().
 			Build()
 		if err != nil {
 			return -1, nil, err

--- a/services/index/internal/controller/rest/node_handler.go
+++ b/services/index/internal/controller/rest/node_handler.go
@@ -561,6 +561,7 @@ func (handler *nodeHandler) Validate(c *gin.Context) {
 	validator, err := schemavalidator.NewBuilder().
 		WithURLSchemas(config.Values.Library.InternalURL, linkedSchemas).
 		WithStrProfile(string(jsonString)).
+		WithCustomValidation().
 		Build()
 	if err != nil {
 		// Log the error for internal debugging and auditing.

--- a/services/validation/internal/service/validation.go
+++ b/services/validation/internal/service/validation.go
@@ -109,6 +109,7 @@ func (svc *validationService) ValidateNode(node *model.Node) {
 	validator, err = schemavalidator.NewBuilder().
 		WithURLSchemas(config.Values.Library.InternalURL, linkedSchemas).
 		WithURLProfile(node.ProfileURL).
+		WithCustomValidation().
 		Build()
 	if err != nil {
 		// Log the error for internal debugging and auditing.


### PR DESCRIPTION
Add validation for basic fields.

```
lat -- -90 <= 0 <= 90
lon -- -180 < =0 <= 180
name -- 200 characters
locality/region -- 100 characters
country -- 3 characters (in case we switch to 3 character ISO codes in the future)
tags -- 100 characters per tag, 100 tags maximum
primary_url -- 2000 characters
```

---

resolve #556