### PR TITLE
feat: ignore extra fields when generating profileHash

### DIFF
--- a/pkg/cryptoutil/cryptoutil.go
+++ b/pkg/cryptoutil/cryptoutil.go
@@ -6,7 +6,6 @@ import (
 )
 
 // ComputeSHA256 computes the SHA-256 hash of the given input string.
-// If the input is a JSON string, please use jsonutil.Hash.
 func ComputeSHA256(input string) string {
 	hash := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(hash[:])

--- a/pkg/cryptoutil/cryptoutil.go
+++ b/pkg/cryptoutil/cryptoutil.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 )
 
-func GetSHA256(s string) string {
-	h := sha256.New()
-	defer h.Reset()
-	h.Write([]byte(s))
-	return hex.EncodeToString(h.Sum(nil))
+// ComputeSHA256 computes the SHA-256 hash of the given input string.
+// If the input is a JSON string, please use jsonutil.Hash.
+func ComputeSHA256(input string) string {
+	hash := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(hash[:])
 }

--- a/pkg/cryptoutil/cryptoutil_test.go
+++ b/pkg/cryptoutil/cryptoutil_test.go
@@ -1,20 +1,40 @@
-package cryptoutil
+package cryptoutil_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/cryptoutil"
 )
 
-func TestGetSHA256(t *testing.T) {
-	assert.Equal(
-		t,
-		"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-		GetSHA256("hello world"),
-	)
-	assert.Equal(
-		t,
-		"ab413dfeee7bdb1aa0f9b7fcef435cee5b183b022c5e719e575ca9e03d51b709",
-		GetSHA256("murmurations"),
-	)
+func TestComputeSHA256(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "empty string",
+			input:  "",
+			expect: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:   "hello world",
+			input:  "hello world",
+			expect: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+		{
+			name:   "12345",
+			input:  "12345",
+			expect: "5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := cryptoutil.ComputeSHA256(tt.input)
+			require.Equal(t, tt.expect, actual)
+		})
+	}
 }

--- a/pkg/importutil/importutil.go
+++ b/pkg/importutil/importutil.go
@@ -2,8 +2,6 @@ package importutil
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/constant"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/logger"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/mongo"
 )
@@ -72,21 +71,6 @@ func GetMapping(schemaName string) (map[string]string, error) {
 	return schema, nil
 }
 
-func Hash(doc string) (string, error) {
-	// ref: https://stackoverflow.com/questions/55256365/how-to-obtain-same-hash-from-json
-	var v interface{}
-	err := json.Unmarshal([]byte(doc), &v)
-	if err != nil {
-		return "", err
-	}
-	hashDoc, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(hashDoc)
-	return hex.EncodeToString(sum[0:]), nil
-}
-
 func MapFieldsName(
 	profile map[string]interface{},
 	mapping map[string]string,
@@ -125,8 +109,9 @@ func MapProfile(
 	// Convert KVM field names to Org Schema field names
 	profileJSON := MapFieldsName(profile, mapping)
 
-	// Hash the updated data
-	profileHash, err := HashProfile(profileJSON)
+	// Hash the updated data.
+	// TODO
+	profileHash, err := jsonutil.Hash(profileJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -162,18 +147,6 @@ func MapProfile(
 	}
 
 	return profileJSON, nil
-}
-
-func HashProfile(profile map[string]interface{}) (string, error) {
-	doc, err := json.Marshal(profile)
-	if err != nil {
-		return "", err
-	}
-	profileHash, err := Hash(string(doc))
-	if err != nil {
-		return "", err
-	}
-	return profileHash, nil
 }
 
 func Validate(

--- a/pkg/jsonutil/jsonutil.go
+++ b/pkg/jsonutil/jsonutil.go
@@ -1,20 +1,61 @@
 package jsonutil
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
 
-func ToJSON(s string) map[string]interface{} {
-	var raw map[string]interface{}
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/cryptoutil"
+)
+
+// ToJSON converts a JSON string to a map.
+func ToJSON(s string) map[string]any {
+	var raw map[string]any
 	err := json.Unmarshal([]byte(s), &raw)
 	if err != nil {
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 	return raw
 }
 
-func ToString(m map[string]interface{}) string {
+// ToString converts a map to a JSON string.
+func ToString(m any) string {
 	jsonString, err := json.Marshal(m)
 	if err != nil {
 		return ""
 	}
 	return string(jsonString)
+}
+
+// Hash computes the SHA-256 hash of the provided JSON data.
+//
+// The function ensures that different representations of the same JSON data
+// (e.g., with fields in different orders) will produce the same hash.
+// This is achieved by parsing the input JSON into a normalized format before hashing.
+func Hash(data any) (string, error) {
+	var doc []byte
+	var err error
+
+	switch v := data.(type) {
+	case string:
+		doc = []byte(v)
+	case map[string]interface{}:
+		doc, err = json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+	default:
+		return "", fmt.Errorf("unsupported json data type")
+	}
+
+	// Normalize the JSON data.
+	var parsedData interface{}
+	if err := json.Unmarshal(doc, &parsedData); err != nil {
+		return "", err
+	}
+	normalizedJSON, err := json.Marshal(parsedData)
+	if err != nil {
+		return "", err
+	}
+
+	return cryptoutil.ComputeSHA256(string(normalizedJSON)), nil
 }

--- a/pkg/jsonutil/jsonutil_test.go
+++ b/pkg/jsonutil/jsonutil_test.go
@@ -1,9 +1,11 @@
-package jsonutil
+package jsonutil_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonutil"
 )
 
 func TestToJSON(t *testing.T) {
@@ -39,7 +41,7 @@ func TestToJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ToJSON(tt.input)
+			result := jsonutil.ToJSON(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -73,8 +75,172 @@ func TestToString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ToString(tt.input)
+			result := jsonutil.ToString(tt.input)
 			require.JSONEq(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name          string
+		originalJSON  any
+		alternateJSON any
+		expErr        bool
+	}{
+		{
+			name:          "Basic JSON",
+			originalJSON:  `{"a": 1, "b": 2}`,
+			alternateJSON: `{"b": 2, "a": 1}`,
+			expErr:        false,
+		},
+		{
+			name: "Complex Nested JSON",
+			originalJSON: `{
+				"user": {
+				  "id": 12345,
+				  "name": "John Doe",
+				  "email": "johndoe@example.com",
+				  "addresses": [
+					{
+					  "street": "123 Main St",
+					  "city": "Anytown",
+					  "state": "CA",
+					  "zip": "12345"
+					},
+					{
+					  "street": "456 Elm St",
+					  "city": "Othertown",
+					  "state": "TX",
+					  "zip": "67890"
+					}
+				  ],
+				  "phoneNumbers": ["123-456-7890", "987-654-3210"],
+				  "isActive": true,
+				  "roles": ["admin", "user", "guest"],
+				  "preferences": {
+					"theme": "dark",
+					"language": "en-US",
+					"notifications": {
+					  "email": true,
+					  "sms": false,
+					  "push": true
+					}
+				  }
+				},
+				"products": [
+				  {
+					"id": 1,
+					"name": "Laptop",
+					"brand": "Brand A",
+					"price": 1000.50
+				  },
+				  {
+					"id": 2,
+					"name": "Phone",
+					"brand": "Brand B",
+					"price": 500.25
+				  }
+				],
+				"orderIDs": [101, 102, 103, 104],
+				"timestamps": [1627890123, 1627890456, 1627890789],
+				"messages": [
+				  "Welcome to our platform!",
+				  "Your order has been shipped.",
+				  "Thank you for your purchase."
+				]
+			  }`,
+			alternateJSON: `{
+				"products": [
+				  {
+					"id": 1,
+					"name": "Laptop",
+					"price": 1000.50,
+					"brand": "Brand A"
+				  },
+				  {
+					"id": 2,
+					"brand": "Brand B",
+					"name": "Phone",
+					"price": 500.25
+				  }
+				],
+				"messages": [
+				  "Welcome to our platform!",
+				  "Your order has been shipped.",
+				  "Thank you for your purchase."
+				],
+				"orderIDs": [101, 102, 103, 104],
+				"timestamps": [1627890123, 1627890456, 1627890789],
+				"user": {
+				  "name": "John Doe",
+				  "email": "johndoe@example.com",
+				  "phoneNumbers": ["123-456-7890", "987-654-3210"],
+				  "id": 12345,
+				  "roles": ["admin", "user", "guest"],
+				  "addresses": [
+					{
+					  "street": "123 Main St",
+					  "city": "Anytown",
+					  "state": "CA",
+					  "zip": "12345"
+					},
+					{
+					  "street": "456 Elm St",
+					  "city": "Othertown",
+					  "state": "TX",
+					  "zip": "67890"
+					}
+				  ],
+				  "isActive": true,
+				  "preferences": {
+					"theme": "dark",
+					"language": "en-US",
+					"notifications": {
+					  "email": true,
+					  "sms": false,
+					  "push": true
+					}
+				  }
+				}
+			  }`,
+			expErr: false,
+		},
+		{
+			name: "Map Format JSON",
+			originalJSON: map[string]interface{}{
+				"name":     "Alice",
+				"age":      30,
+				"location": "New York",
+			},
+			alternateJSON: map[string]interface{}{
+				"location": "New York",
+				"age":      30,
+				"name":     "Alice",
+			},
+			expErr: false,
+		},
+		{
+			name:          "Invalid JSON",
+			originalJSON:  `{"a": 1, "b": 2`,
+			alternateJSON: `{"a": 1, "b": 2`,
+			expErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1, err1 := jsonutil.Hash(tt.originalJSON)
+			hash2, err2 := jsonutil.Hash(tt.alternateJSON)
+
+			if tt.expErr {
+				require.Error(t, err1)
+				require.Error(t, err2)
+			} else {
+				require.NoError(t, err1)
+				require.NoError(t, err2)
+				require.Equal(t, hash1, hash2, "Hashes should be equal for %s and %s", tt.originalJSON, tt.alternateJSON)
+			}
 		})
 	}
 }

--- a/pkg/profile/profilehasher/profilehasher.go
+++ b/pkg/profile/profilehasher/profilehasher.go
@@ -1,0 +1,133 @@
+package profilehasher
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonutil"
+)
+
+// defaultFields represents the default fields to be considered for hashing.
+var defaultFields = map[string]bool{
+	"country":        true,
+	"geolocation":    true,
+	"last_updated":   true,
+	"linked_schemas": true,
+	"locality":       true,
+	"name":           true,
+	"primary_url":    true,
+	"profile_url":    true,
+	"region":         true,
+	"status":         true,
+	"tags":           true,
+	"latitude":       true,
+	"longitude":      true,
+}
+
+// ProfileHash contains data required to hash a profile.
+type ProfileHash struct {
+	profileURL       string
+	libraryURL       string
+	profile          map[string]interface{}
+	fieldsForHashing map[string]bool
+}
+
+// New initializes a new ProfileHash instance.
+func New(profileURL, libraryURL string) *ProfileHash {
+	fieldsForHashing := make(map[string]bool)
+	for key := range defaultFields {
+		fieldsForHashing[key] = true
+	}
+
+	return &ProfileHash{
+		profileURL:       profileURL,
+		libraryURL:       libraryURL,
+		fieldsForHashing: fieldsForHashing,
+	}
+}
+
+// Hash computes the hash for the profile.
+func (p *ProfileHash) Hash() (string, error) {
+	profileData, err := p.fetchData(p.profileURL)
+	if err != nil {
+		return "", err
+	}
+
+	err = p.parseProfile(profileData)
+	if err != nil {
+		return "", err
+	}
+
+	err = p.populateFieldsForHashing()
+	if err != nil {
+		return "", err
+	}
+
+	filteredProfile := p.filterProfileFields()
+
+	return jsonutil.Hash(filteredProfile)
+}
+
+func (p *ProfileHash) fetchData(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch data: %s", resp.Status)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func (p *ProfileHash) parseProfile(data []byte) error {
+	return json.Unmarshal(data, &p.profile)
+}
+
+func (p *ProfileHash) populateFieldsForHashing() error {
+	linkedSchemas, ok := p.profile["linked_schemas"].([]interface{})
+
+	if ok {
+		for _, schemaIdentifier := range linkedSchemas {
+			schemaURL := p.constructSchemaURL(schemaIdentifier.(string))
+
+			schemaData, err := p.fetchData(schemaURL)
+			if err != nil {
+				return err
+			}
+
+			var currentSchema map[string]interface{}
+			err = json.Unmarshal(schemaData, &currentSchema)
+			if err != nil {
+				return err
+			}
+
+			properties, ok := currentSchema["properties"].(map[string]interface{})
+			if ok {
+				for key := range properties {
+					p.fieldsForHashing[key] = true
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *ProfileHash) filterProfileFields() map[string]interface{} {
+	filteredProfile := make(map[string]interface{})
+	for key, value := range p.profile {
+		if p.fieldsForHashing[key] {
+			filteredProfile[key] = value
+		}
+	}
+	return filteredProfile
+}
+
+func (p *ProfileHash) constructSchemaURL(linkedSchema string) string {
+	return fmt.Sprintf("%s/v2/schemas/%s", p.libraryURL, linkedSchema)
+}

--- a/pkg/profile/profilehasher/profilehasher_test.go
+++ b/pkg/profile/profilehasher/profilehasher_test.go
@@ -1,0 +1,158 @@
+package profilehasher_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/profile/profilehasher"
+)
+
+func createProfileServer(t *testing.T, response string) *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte(response))
+			require.NoError(t, err, "Failed to write response")
+		}),
+	)
+}
+
+func createLibraryServer(
+	t *testing.T,
+	responses map[string]string,
+) *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.URL.Path, "/v2/schemas/") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, err := w.Write([]byte("Invalid schema path"))
+				require.NoError(t, err, "Failed to write response")
+				return
+			}
+			schemaName := path.Base(r.URL.Path)
+			if response, ok := responses[schemaName]; ok {
+				_, err := w.Write([]byte(response))
+				require.NoError(t, err, "Failed to write response")
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+				_, err := w.Write([]byte("Schema not found"))
+				require.NoError(t, err, "Failed to write response")
+			}
+		}),
+	)
+}
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name            string
+		profileResponse string
+		libraryMappings map[string]string // Map of URL path to response
+		expectedErr     error
+		expectedHash    string
+	}{
+		{
+			name: "Profile with Only Name",
+			profileResponse: `{
+				"name": "Test Organization"
+			}`,
+			libraryMappings: map[string]string{},
+			expectedErr:     nil,
+			expectedHash:    "46ad5935291b46fa2a052d965a9208af03c8a8611e5898b3a7c7d0e39649471b",
+		},
+		{
+			name: "Profile with Redundant Field",
+			profileResponse: `{
+				"redundant_field": "Some value"
+			}`,
+			libraryMappings: map[string]string{},
+			expectedErr:     nil,
+			expectedHash:    "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+		},
+		{
+			name: "Profile with One Linked Schema",
+			profileResponse: `{
+				"linked_schemas": ["schema_one-v1.0.0"],
+				"name": "Test Organization",
+				"primary_url": "https://test-organization.com",
+				"tags": ["Test Tag"]
+			}`,
+			libraryMappings: map[string]string{
+				"schema_one-v1.0.0": `{
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"primary_url": {
+							"type": "string"
+						},
+						"tags": {
+							"type": "array"
+						}
+					}
+				}`,
+			},
+			expectedErr:  nil,
+			expectedHash: "9be6e1a378d770d4213c0a3df56cbb5fa7a2605ebbbceeaec2b41835ad23cb1f",
+		},
+		{
+			name: "Profile with Multiple Linked Schemas",
+			profileResponse: `{
+				"linked_schemas": ["schema_one-v1.0.0", "schema_two-v1.0.0"],
+				"name": "Multi-Schema Organization",
+				"primary_url": "https://multi-schema-organization.com",
+				"tags": ["Test Tag"],
+				"additional_field": "Some additional data",
+				"redundant_field": "Some value"
+			}`,
+			libraryMappings: map[string]string{
+				"schema_one-v1.0.0": `{
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"primary_url": {
+							"type": "string"
+						},
+						"tags": {
+							"type": "array"
+						}
+					}
+				}`,
+				"schema_two-v1.0.0": `{
+					"properties": {
+						"additional_field": {
+							"type": "string"
+						}
+					}
+				}`,
+			},
+			expectedErr:  nil,
+			expectedHash: "61f723f41546908316bd647b25be8aafaf1422981f66ad5e9f308d0687326fdc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profileServer := createProfileServer(t, tt.profileResponse)
+			defer profileServer.Close()
+
+			libraryServer := createLibraryServer(t, tt.libraryMappings)
+			defer libraryServer.Close()
+
+			ph := profilehasher.New(profileServer.URL, libraryServer.URL)
+			hash, err := ph.Hash()
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedHash, hash)
+			}
+		})
+	}
+}

--- a/pkg/profile/profilevalidator/builder.go
+++ b/pkg/profile/profilevalidator/builder.go
@@ -1,43 +1,43 @@
-package schemavalidator
+package profilevalidator
 
 import "fmt"
 
-// Builder is a builder type for creating SchemaValidator instances.
+// Builder is a builder type for creating ProfileValidator instances.
 type Builder struct {
-	// schemaValidator is the SchemaValidator instance being constructed.
-	schemaValidator *SchemaValidator
+	// profilevalidator is the ProfileValidator instance being constructed.
+	profilevalidator *ProfileValidator
 }
 
 // NewBuilder creates and returns a new Builder.
 func NewBuilder() *Builder {
 	return &Builder{
-		schemaValidator: &SchemaValidator{},
+		profilevalidator: &ProfileValidator{},
 	}
 }
 
-// WithURLSchemas sets the base URL and the schemas for the SchemaValidator to be built.
+// WithURLSchemas sets the base URL and the schemas for the ProfileValidator to be built.
 func (b *Builder) WithURLSchemas(baseURL string, schemas []string) *Builder {
-	b.schemaValidator.Schemas = schemas
-	b.schemaValidator.SchemaLoader = &URLSchemaLoader{BaseURL: baseURL}
+	b.profilevalidator.Schemas = schemas
+	b.profilevalidator.SchemaLoader = &URLSchemaLoader{BaseURL: baseURL}
 	return b
 }
 
-// WithStrSchemas sets the schemas for the SchemaValidator to be built.
+// WithStrSchemas sets the schemas for the ProfileValidator to be built.
 func (b *Builder) WithStrSchemas(schemas []string) *Builder {
-	b.schemaValidator.Schemas = schemas
-	b.schemaValidator.SchemaLoader = &StrSchemaLoader{}
+	b.profilevalidator.Schemas = schemas
+	b.profilevalidator.SchemaLoader = &StrSchemaLoader{}
 	return b
 }
 
 // WithURLProfile sets the URL for loading the data to be validated.
 func (b *Builder) WithURLProfile(dataURL string) *Builder {
-	b.schemaValidator.ProfileLoader = &URLProfileLoader{dataURL: dataURL}
+	b.profilevalidator.ProfileLoader = &URLProfileLoader{dataURL: dataURL}
 	return b
 }
 
 // WithStrProfile sets the data string to be validated.
 func (b *Builder) WithStrProfile(dataString string) *Builder {
-	b.schemaValidator.ProfileLoader = &StrProfileLoader{dataString: dataString}
+	b.profilevalidator.ProfileLoader = &StrProfileLoader{dataString: dataString}
 	return b
 }
 
@@ -45,30 +45,30 @@ func (b *Builder) WithStrProfile(dataString string) *Builder {
 func (b *Builder) WithMapProfile(
 	dataMap map[string]interface{},
 ) *Builder {
-	b.schemaValidator.ProfileLoader = &MapProfileLoader{dataMap: dataMap}
+	b.profilevalidator.ProfileLoader = &MapProfileLoader{dataMap: dataMap}
 	return b
 }
 
 // WithCustomValidation enables to custom validation.
 func (b *Builder) WithCustomValidation() *Builder {
-	b.schemaValidator.CustomValidation = true
+	b.profilevalidator.CustomValidation = true
 	return b
 }
 
-// Build validates the builder state and returns the built SchemaValidator.
-func (b *Builder) Build() (*SchemaValidator, error) {
+// Build validates the builder state and returns the built ProfileValidator.
+func (b *Builder) Build() (*ProfileValidator, error) {
 	// Check that required fields are set.
-	if b.schemaValidator.Schemas == nil {
+	if b.profilevalidator.Schemas == nil {
 		return nil, fmt.Errorf("schemas must be provided")
 	}
-	if b.schemaValidator.SchemaLoader == nil {
+	if b.profilevalidator.SchemaLoader == nil {
 		return nil, fmt.Errorf("a schema loader must be provided")
 	}
-	if b.schemaValidator.ProfileLoader == nil {
+	if b.profilevalidator.ProfileLoader == nil {
 		return nil, fmt.Errorf("a data loader must be provided")
 	}
 
-	profileData, err := b.schemaValidator.ProfileLoader.Load().LoadJSON()
+	profileData, err := b.profilevalidator.ProfileLoader.Load().LoadJSON()
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to load JSON from the profile URL: %w",
@@ -83,7 +83,7 @@ func (b *Builder) Build() (*SchemaValidator, error) {
 		)
 	}
 
-	b.schemaValidator.JSON = jsonMap
+	b.profilevalidator.JSON = jsonMap
 
-	return b.schemaValidator, nil
+	return b.profilevalidator, nil
 }

--- a/pkg/profile/profilevalidator/cutomvalidator.go
+++ b/pkg/profile/profilevalidator/cutomvalidator.go
@@ -1,4 +1,4 @@
-package schemavalidator
+package profilevalidator
 
 import (
 	"encoding/json"

--- a/pkg/profile/profilevalidator/profilevalidator.go
+++ b/pkg/profile/profilevalidator/profilevalidator.go
@@ -1,4 +1,4 @@
-package schemavalidator
+package profilevalidator
 
 import (
 	"fmt"
@@ -77,23 +77,23 @@ func (mv *MapProfileLoader) Load() gojsonschema.JSONLoader {
 	return gojsonschema.NewGoLoader(mv.dataMap)
 }
 
-// SchemaValidator is the main struct of this package, which performs
-// the validation against the JSON schemas.
-type SchemaValidator struct {
+// ProfileValidator is the main struct of this package, which performs
+// the validation against the profile JSON.
+type ProfileValidator struct {
+	// The loader that fetches the profile data.
+	ProfileLoader ProfileLoader
+	// The Profile JSON data.
+	JSON map[string]interface{}
 	// The schemas to be used for validation.
 	Schemas []string
 	// The loader that fetches the schemas.
 	SchemaLoader Loader
-	// The loader that fetches the profile data.
-	ProfileLoader ProfileLoader
-	// The JSON data.
-	JSON map[string]interface{}
 	// Enable/disable custom validation.
 	CustomValidation bool
 }
 
 // Validate validates the data against the schemas and returns the validation result.
-func (v *SchemaValidator) Validate() *ValidationResult {
+func (v *ProfileValidator) Validate() *ValidationResult {
 	finalResult := NewValidationResult()
 
 	for _, schemaStr := range v.Schemas {
@@ -150,7 +150,7 @@ func (v *SchemaValidator) Validate() *ValidationResult {
 }
 
 // CustomValidate performs custom validation on the JSON data.
-func (v *SchemaValidator) CustomValidate() *ValidationResult {
+func (v *ProfileValidator) CustomValidate() *ValidationResult {
 	finalResult := NewValidationResult()
 
 	validators := map[string]CustomValidator{

--- a/pkg/profile/profilevalidator/profilevalidator_test.go
+++ b/pkg/profile/profilevalidator/profilevalidator_test.go
@@ -1,4 +1,4 @@
-package schemavalidator_test
+package profilevalidator_test
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/schemavalidator"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/profile/profilevalidator"
 )
 
 var StrSchema = `{}`
@@ -140,7 +140,7 @@ func TestValidate_CustomValidator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator, err := schemavalidator.NewBuilder().
+			validator, err := profilevalidator.NewBuilder().
 				WithStrSchemas([]string{StrSchema}).
 				WithStrProfile(tt.profile).
 				WithCustomValidation().

--- a/pkg/profile/profilevalidator/validationresult.go
+++ b/pkg/profile/profilevalidator/validationresult.go
@@ -1,4 +1,4 @@
-package schemavalidator
+package profilevalidator
 
 // ValidationResult is the results from a schema validation operation.
 type ValidationResult struct {

--- a/services/cronjob/dataproxyrefresher/cmd/dataproxyrefresher/main.go
+++ b/services/cronjob/dataproxyrefresher/cmd/dataproxyrefresher/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lucsky/cuid"
 
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/importutil"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/logger"
 	mongodb "github.com/MurmurationsNetwork/MurmurationsServices/pkg/mongo"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/cronjob/dataproxyrefresher/config"
@@ -101,7 +102,9 @@ func main() {
 				)
 				cleanUp()
 			}
-			profileHash, err := importutil.Hash(string(doc))
+
+			// TODO
+			profileHash, err := jsonutil.Hash(string(doc))
 			if err != nil {
 				logger.Error(
 					"Failed to hash data. Profile CUID: "+profile.Cuid,

--- a/services/dataproxy/internal/service/batch.go
+++ b/services/dataproxy/internal/service/batch.go
@@ -12,7 +12,8 @@ import (
 
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/importutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonapi"
-	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/schemavalidator"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonutil"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/profile/profilevalidator"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/validatenode"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/dataproxy/config"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/dataproxy/internal/model"
@@ -86,9 +87,9 @@ func (s *batchService) Validate(
 			return line, nil, err
 		}
 
-		validator, err := schemavalidator.NewBuilder().
-			WithStrSchemas(validateJSONSchemas).
+		validator, err := profilevalidator.NewBuilder().
 			WithMapProfile(profile).
+			WithStrSchemas(validateJSONSchemas).
 			WithCustomValidation().
 			Build()
 		if err != nil {
@@ -159,8 +160,8 @@ func (s *batchService) Import(
 			), nil
 		}
 
-		// Hash profile
-		profileHash, err := importutil.HashProfile(profile)
+		// TODO
+		profileHash, err := jsonutil.Hash(profile)
 		if err != nil {
 			return batchID, line, nil, err
 		}
@@ -288,8 +289,8 @@ func (s *batchService) Edit(
 			), nil
 		}
 
-		// Hash profile
-		profileHash, err := importutil.HashProfile(profile)
+		// TODO
+		profileHash, err := jsonutil.Hash(profile)
 		if err != nil {
 			return line, nil, err
 		}

--- a/services/index/internal/controller/rest/node_handler.go
+++ b/services/index/internal/controller/rest/node_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/dateutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/jsonapi"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/logger"
-	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/schemavalidator"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/profile/profilevalidator"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/config"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/internal/index"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/internal/model"
@@ -558,7 +558,7 @@ func (handler *nodeHandler) Validate(c *gin.Context) {
 	linkedSchemas = append(linkedSchemas, "default-v2.0.0")
 
 	// Validate against schemes specify inside the profile data.
-	validator, err := schemavalidator.NewBuilder().
+	validator, err := profilevalidator.NewBuilder().
 		WithURLSchemas(config.Values.Library.InternalURL, linkedSchemas).
 		WithStrProfile(string(jsonString)).
 		WithCustomValidation().

--- a/test/e2e-tests.json
+++ b/test/e2e-tests.json
@@ -4,7 +4,7 @@
 		"name": "Murmurations API Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "28537014",
-		"_collection_link": "https://ic3network.postman.co/workspace/Murmurations~a621deb5-92bc-4d76-a95a-a01f322954c8/collection/10168004-c985860d-4b36-44da-9d69-79f8a19af2c8?action=share&creator=28537014&source=collection_link"
+		"_collection_link": "https://ic3network.postman.co/workspace/Murmurations~a621deb5-92bc-4d76-a95a-a01f322954c8/collection/10168004-c985860d-4b36-44da-9d69-79f8a19af2c8?action=share&source=collection_link"
 	},
 	"item": [
 		{
@@ -879,7 +879,7 @@
 									"})",
 									"",
 									"pm.test(`${pm.variables.get(\"folder_name\")} - (${pm.variables.get(\"test_counter\")}) ${pm.info.requestName} - should return correct profile_hash`, () => {",
-									"    pm.expect(jsonData.data.profile_hash).to.eq(\"6f2e7a7d74538dc393ee090ca72a5c97931c558ab8aadbedd456f35daeed950b\")",
+									"    pm.expect(jsonData.data.profile_hash).to.eq(\"4fb2953fe653771d33e0b3b3317901db781b4aaace9bbde890558e7ca4fa3088\")",
 									"})",
 									"",
 									"pm.test(`${pm.variables.get(\"folder_name\")} - (${pm.variables.get(\"test_counter\")}) ${pm.info.requestName} - should not return linked_schemas list`, () => {",


### PR DESCRIPTION
## TODO

- [x] Create a `profilehasher` package that fetches and processes profile data, filters out unnecessary fields based on the properties of linked schemas, and computes a hash for the resulting profile.
- [x] Understand what dataproxy and dataproxyferer are doing, and change the hashing logic accordingly.

---

resolves #563