### PR TITLE
Fix the E2E tests when the profile is invalid

### DIFF
--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,0 +1,11 @@
+package core
+
+// ProfileFetchError represents an error encountered when trying to fetch a profile.
+type ProfileFetchError struct {
+	Reason string
+}
+
+// Error function to represent the ProfileFetchError as a string.
+func (e ProfileFetchError) Error() string {
+	return "Profile fetch error: " + e.Reason
+}

--- a/test/e2e-tests.json
+++ b/test/e2e-tests.json
@@ -1826,7 +1826,7 @@
 									"})",
 									"",
 									"pm.test(`${pm.variables.get(\"folder_name\")} - (${pm.variables.get(\"test_counter\")}) ${pm.info.requestName} - should return non-existent profile detail`, () => {",
-									"    pm.expect(jsonData.meta.profile_url).to.contain('https://ic3.dev/murmurations/does-not-exist.json')",
+									"    pm.expect(jsonData.errors[0].detail).to.contain('https://ic3.dev/murmurations/does-not-exist.json')",
 									"})",
 									""
 								],


### PR DESCRIPTION
Introduce a new error to ensure that 'indexz' returns the correct error when the hash function cannot read the profile JSON properly.

