### PR TITLE
fix: remove warning in yaml files

### DIFF
--- a/charts/murmurations/charts/ingress/templates/ingress/ingress.yaml
+++ b/charts/murmurations/charts/ingress/templates/ingress/ingress.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   name: ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- if not (eq .Values.global.env "development") }}
@@ -11,6 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if eq .Values.global.env "production" }}
   tls:
     - hosts:
@@ -36,7 +36,7 @@ spec:
     {{- end }}
       http:
         paths:
-          - pathType: Prefix
+          - pathType: ImplementationSpecific
             path: /(|$)(.*)
             backend:
               service:
@@ -52,7 +52,7 @@ spec:
     {{- end }}
       http:
         paths:
-          - pathType: Prefix
+          - pathType: ImplementationSpecific
             path: /(|$)(.*)
             backend:
               service:
@@ -68,7 +68,7 @@ spec:
     {{- end }}
       http:
         paths:
-          - pathType: Prefix
+          - pathType: ImplementationSpecific
             path: /(|$)(.*)
             backend:
               service:
@@ -106,8 +106,8 @@ spec:
     {{- end }}
       http:
         paths:
-          - pathType: Prefix
-            path: /
+          - pathType: ImplementationSpecific
+            path: /(|$)(.*)
             backend:
               service:
                 name: kube-prom-stack-grafana

--- a/charts/murmurations/charts/schemaparser/templates/redis/dpl.yaml
+++ b/charts/murmurations/charts/schemaparser/templates/redis/dpl.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # Limit old ReplicaSets to reduce clutter. 0 means only keep the current one.
-  revisionHistoryLimit: 0
   name: schemaparser-redis
   labels:
     app: redis
     role: leader
 spec:
+  # Limit old ReplicaSets to reduce clutter. 0 means only keep the current one.
+  revisionHistoryLimit: 0
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
1. Use `spec.ingressClassName` instead of `kubernetes.io/ingress.class`.
2. Use `ImplementationSpecific` instead of `prefix`. (prefix does not support regex)
3. Move `revisionHistoryLimit` to the right location.

---

resolves #579