### PR TITLE
fix: ensure validation process only read the profile once

### DIFF
--- a/pkg/profile/profilevalidator/builder.go
+++ b/pkg/profile/profilevalidator/builder.go
@@ -29,12 +29,6 @@ func (b *Builder) WithStrSchemas(schemas []string) *Builder {
 	return b
 }
 
-// WithURLProfile sets the URL for loading the data to be validated.
-func (b *Builder) WithURLProfile(dataURL string) *Builder {
-	b.profilevalidator.ProfileLoader = &URLProfileLoader{dataURL: dataURL}
-	return b
-}
-
 // WithStrProfile sets the data string to be validated.
 func (b *Builder) WithStrProfile(dataString string) *Builder {
 	b.profilevalidator.ProfileLoader = &StrProfileLoader{dataString: dataString}

--- a/services/index/internal/service/node.go
+++ b/services/index/internal/service/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/dateutil"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/event"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/httputil"
+	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/logger"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/nats"
 	"github.com/MurmurationsNetwork/MurmurationsServices/pkg/profile/profilehasher"
 	"github.com/MurmurationsNetwork/MurmurationsServices/services/index/config"
@@ -65,6 +66,11 @@ func (s *nodeService) SetNodeValid(node *model.Node) error {
 	}
 
 	if err := s.elasticRepo.IndexByID(node.ID, profile.GetJSON()); err != nil {
+		errMsg := fmt.Sprintf(
+			"Error indexing node ID '%s' in Elastic repository",
+			node.ID,
+		)
+		logger.Error(errMsg, err)
 		node.SetStatusPostFailed()
 		return s.mongoRepo.Update(node)
 	}

--- a/services/validation/internal/service/validation_test.go
+++ b/services/validation/internal/service/validation_test.go
@@ -9,70 +9,51 @@ import (
 func TestGetLinkedSchemas(t *testing.T) {
 	tests := []struct {
 		name          string
-		data          interface{}
-		expectedOk    bool
+		data          string
+		expectedError string
 		expectedValue []string
 	}{
 		{
-			name:       "Test with nil data",
-			data:       nil,
-			expectedOk: false,
+			name:          "Test with empty JSON object",
+			data:          "{}",
+			expectedError: "linked schemas not found in profile",
 		},
 		{
-			name:       "Test with empty map",
-			data:       map[string]interface{}{},
-			expectedOk: false,
+			name:          "Test with wrong key",
+			data:          `{"profile_url": "https://ic3.dev/test2.json"}`,
+			expectedError: "linked schemas not found in profile",
 		},
 		{
-			name: "Test with wrong key",
-			data: map[string]interface{}{
-				"profile_url": "https://ic3.dev/test2.json",
-			},
-			expectedOk: false,
+			name:          "Test with wrong type of value",
+			data:          `{"linked_schemas": "https://ic3.dev/test2.json"}`,
+			expectedError: "linked schemas is not an array",
 		},
 		{
-			name: "Test with wrong type of value",
-			data: map[string]interface{}{
-				"linked_schemas": "https://ic3.dev/test2.json",
-			},
-			expectedOk: false,
+			name:          "Test with non-array value",
+			data:          `{"linked_schemas": false}`,
+			expectedError: "linked schemas is not an array",
 		},
 		{
-			name: "Test with false value",
-			data: map[string]interface{}{
-				"linked_schemas": false,
-			},
-			expectedOk: false,
+			name:          "Test with empty array",
+			data:          `{"linked_schemas": []}`,
+			expectedError: "empty linked schemas array",
 		},
 		{
-			name: "Test with empty slice",
-			data: map[string]interface{}{
-				"linked_schemas": []string{},
-			},
-			expectedOk: false,
-		},
-		{
-			name: "Test with string slice",
-			data: map[string]interface{}{
-				"linked_schemas": []string{"https://ic3.dev/test2.json"},
-			},
-			expectedOk: false,
-		},
-		{
-			name: "Test with interface slice",
-			data: map[string]interface{}{
-				"linked_schemas": []interface{}{"https://ic3.dev/test2.json"},
-			},
-			expectedOk:    true,
+			name:          "Test with valid data",
+			data:          `{"linked_schemas": ["https://ic3.dev/test2.json"]}`,
 			expectedValue: []string{"https://ic3.dev/test2.json"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			linkedSchemas, ok := getLinkedSchemas(tt.data)
-			require.Equal(t, tt.expectedOk, ok)
-			if tt.expectedOk {
+			linkedSchemas, err := getLinkedSchemas(tt.data)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err.Error())
+			} else {
+				require.NoError(t, err)
 				require.Equal(t, tt.expectedValue, linkedSchemas)
 			}
 		})


### PR DESCRIPTION
The main changes are in `services/validation/internal/service/validation.go`. We made sure to read the profile once and used it throughout the entire validation process to prevent reading different versions of profile due to network issue.

resolves #605