### PR TITLE
feat: add feature toggle to skip URL check on delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dev:
 #--------------------------
 .PHONY: test
 test:
-	export ENV=test && go test ./...
+	export APP_ENV=test && go test ./...
 
 #--------------------------
 # Run the end-to-end (E2E) tests using newman.

--- a/charts/murmurations/charts/index/templates/index/config.yaml
+++ b/charts/murmurations/charts/index/templates/index/config.yaml
@@ -1,8 +1,23 @@
+{{- $env := .Values.global.env }}
+{{- $isProd := eq $env "production" }}
+{{- $isStaging := eq $env "staging" }}
+{{- $isPretest := eq $env "pretest" }}
+{{- $isDev := eq $env "development" }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: index-app-config
 data:
+  {{ if $isProd }}
+  APP_ENV: "production"
+  {{ else if $isStaging }}
+  APP_ENV: "staging"
+  {{ else if $isPretest }}
+  APP_ENV: "pretest"
+  {{ else }}
+  APP_ENV: "development"
+  {{- end }}
   SERVER_PORT: "8080"
   SERVER_TIMEOUT_READ: 5s
   SERVER_TIMEOUT_WRITE: 10s
@@ -20,9 +35,9 @@ data:
   GET_RATE_LIMIT_PERIOD: 6000-M
   POST_RATE_LIMIT_PERIOD: 6000-M
   # Delete TTL, notice: need to modify the value in nodecleaner service as well
-  {{- if eq .Values.global.env "production" }}
+  {{ if $isProd }}
   DELETED_TTL: "1209600" # 2 weeks = 14 days * 24 hrs * 60 mins * 60 secs
-  {{- else if eq .Values.global.env "staging" }}
+  {{ else if $isStaging }}
   DELETED_TTL: "1209600" # 2 weeks
   {{- else }}
   DELETED_TTL: "120" # 2 mins

--- a/pkg/elastic/client_interface.go
+++ b/pkg/elastic/client_interface.go
@@ -29,7 +29,7 @@ type esClientInterface interface {
 }
 
 func init() {
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		Client = &mockClient{}
 		return
 	}
@@ -39,7 +39,7 @@ func init() {
 func NewClient(url string) error {
 	var client *elastic.Client
 
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("APP_ENV") != "test" {
 		operation := func() error {
 			log := logger.GetLogger()
 

--- a/pkg/event/base_publisher.go
+++ b/pkg/event/base_publisher.go
@@ -50,7 +50,7 @@ func (p *publisher) SetAckHandler(ackHandler stan.AckHandler) {
 
 func (p *publisher) Publish(data interface{}) {
 	// FIXME: Use Abstraction
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		return
 	}
 	msg, _ := json.Marshal(data)
@@ -59,7 +59,7 @@ func (p *publisher) Publish(data interface{}) {
 
 // PublishSync sends a message to the designated subject using a synchronous approach.
 func (p *publisher) PublishSync(data interface{}) error {
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		return nil
 	}
 

--- a/pkg/mongo/client_interface.go
+++ b/pkg/mongo/client_interface.go
@@ -40,7 +40,7 @@ type mongoClientInterface interface {
 }
 
 func init() {
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		Client = &mockClient{}
 		return
 	}
@@ -50,7 +50,7 @@ func init() {
 func NewClient(url string, dbName string) error {
 	var client *mongo.Client
 
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("APP_ENV") != "test" {
 		var err error
 		client, err = mongo.Connect(
 			context.Background(),

--- a/pkg/nats/client_interface.go
+++ b/pkg/nats/client_interface.go
@@ -20,7 +20,7 @@ type natsClientInterface interface {
 }
 
 func init() {
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		Client = &mockClient{}
 		return
 	}
@@ -30,7 +30,7 @@ func init() {
 func NewClient(stanClusterID, clientID, natsURL string) error {
 	var client stan.Conn
 
-	if os.Getenv("ENV") != "test" {
+	if os.Getenv("APP_ENV") != "test" {
 		opts := []stan.Option{stan.NatsURL(natsURL)}
 
 		operation := func() error {

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -14,7 +14,7 @@ type Redis interface {
 }
 
 func NewClient(url string) Redis {
-	if os.Getenv("ENV") == "test" {
+	if os.Getenv("APP_ENV") == "test" {
 		return &redismock{}
 	}
 	return &redisImpl{

--- a/services/index/config/config.go
+++ b/services/index/config/config.go
@@ -6,7 +6,9 @@ import (
 )
 
 // Values holds all the application's configurations.
-var Values = config{}
+var Values = config{
+	FeatureToggles: make(map[string]bool),
+}
 
 // config is the central configuration holder.
 type config struct {
@@ -22,6 +24,8 @@ type config struct {
 	Nats natsConf
 	// TTL configuration
 	TTL ttlConf
+	// FeatureToggles
+	FeatureToggles map[string]bool
 }
 
 // serverConf contains server configurations.

--- a/services/index/internal/controller/rest/node_handler.go
+++ b/services/index/internal/controller/rest/node_handler.go
@@ -831,7 +831,11 @@ func handleGetNodeErrors(c *gin.Context, err error, nodeID string) {
 	c.JSON(jsonErr[0].Status, res)
 }
 
-func handleDeleteNodeErrors(c *gin.Context, err error, nodeID, profileURL string) {
+func handleDeleteNodeErrors(
+	c *gin.Context,
+	err error,
+	nodeID, profileURL string,
+) {
 	var (
 		notFoundError   index.NotFoundError
 		databaseError   index.DatabaseError

--- a/services/index/pkg/index/middleware.go
+++ b/services/index/pkg/index/middleware.go
@@ -1,0 +1,25 @@
+package index
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+func AllowInNonProductionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Default to restrictive behavior (suitable for production)
+		// Only allow the operation in non-production environments if explicitly specified.
+		if os.Getenv("APP_ENV") != "development" &&
+			os.Getenv("APP_ENV") != "staging" &&
+			os.Getenv("APP_ENV") != "pretest" {
+			c.AbortWithStatusJSON(
+				http.StatusForbidden,
+				gin.H{"error": "Operation not allowed in this environment"},
+			)
+			return
+		}
+		c.Next()
+	}
+}


### PR DESCRIPTION
By invoking the following URL, you can delete a node even if the profile URL still exists:

```
PUT {{indexBaseUrl}}/feature-flag/SkipProfileURLCheckOnDelete?enable=true
```

---

resolves #620