### PR TITLE
Trigger redeployment when leaving a specific comment in the PR

### DIFF
--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,7 +1,7 @@
 # Workflow Description:
 # This GitHub Actions workflow is initiated by specific review comments from
 # authorized users in pull request reviews. It triggers a build and deployment
-# process when a comment containing '/rebuild'.
+# process when a comment containing '/rebuild' is made by an authorized user.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
@@ -14,6 +14,8 @@ on:
     types: [created]
 
 jobs:
+  # Debug Job:
+  # Prints the body of the comment to the console for debugging purposes.
   debug:
     runs-on: ubuntu-latest
     steps:
@@ -21,23 +23,25 @@ jobs:
         run: |
           echo "Comment Body: ${{ github.event.comment.body }}"
 
-  # Job: Check Comment and Trigger Build
-  # Checks if the comment contains '/rebuild' and if the author is
-  # an authorized user. Triggers the build job if conditions are met.
+  # Check Comment and Trigger Build Job:
+  # Verifies if the comment contains '/rebuild' and if the author is an
+  # authorized user (OWNER or COLLABORATOR). Triggers the build job if true.
   check-comment-and-trigger-build:
-    if: contains(github.event.comment.body, '/rebuild')
+    if: >-
+      contains(github.event.comment.body, '/rebuild') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Build Job
         run: echo "Triggering Build Job"
 
-  # Job: Build Docker Image
-  # Builds Docker images for services listed in the matrix, depending on the
-  # 'check-comment-and-trigger-build' job's outcome.
+  # Build Job:
+  # Builds Docker images for the listed services, depending on the outcome of
+  # the 'check-comment-and-trigger-build' job.
   build:
     name: Build Docker Image - ${{ matrix.service }}
-    needs:
-      - check-comment-and-trigger-build
+    needs: check-comment-and-trigger-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,7 +60,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }} # Check out head branch of PR.
+          ref: ${{ github.head_ref }}
 
       - name: DockerHub Login
         uses: docker/login-action@v3.0.0
@@ -67,9 +71,9 @@ jobs:
       - name: Publish Docker Image
         run: make docker-push-${{ matrix.service }} DEPLOY_ENV=pretest
 
-  # Job: Deploy Services
+  # Deploy Job:
   # Handles the deployment of services using the built Docker images.
-  # Depends on the successful completion of the 'build' job.
+  # This job depends on the successful completion of the 'build' job.
   deploy:
     name: Deploy Services
     needs: build

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,7 +1,15 @@
+# This workflow is designed to trigger a build and deployment process based
+# on specific review comments made by authorized users in pull request reviews.
+# When a comment containing '!rebuild images' is detected from an authorized user
+# (Owner, Collaborator, or Member), the workflow initiates a build job for
+# multiple Docker images and then proceeds to deploy these services.
+
 name: Redeploy on Specific Review Comment by Authorized User
 
 # Trigger this workflow on comments created in pull request reviews.
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request_review_comment:
     types: [created]
 
@@ -52,11 +60,11 @@ jobs:
     name: Deploy Services
     needs: build
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_ENV: pretest
+      PRETEST_SERVER_IP: ${{ secrets.PRETEST_SERVER_IP }}
+      PRETEST_KUBECONFIG_PATH: ${{ secrets.PRETEST_KUBECONFIG_PATH }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     steps:
       - name: Run Deployment Script
         run: ./scripts/deploy-services.sh
-        env:
-          PRETEST_SERVER_IP: ${{ secrets.PRETEST_SERVER_IP }}
-          PRETEST_KUBECONFIG_PATH: ${{ secrets.PRETEST_KUBECONFIG_PATH }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          DEPLOY_ENV: pretest

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,8 +1,7 @@
 # Workflow Description:
 # This GitHub Actions workflow is initiated by specific review comments from
 # authorized users in pull request reviews. It triggers a build and deployment
-# process when a comment containing '!rebuild images' is made by an Owner,
-# Collaborator, or Member.
+# process when a comment containing '!rebuild images'.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
@@ -19,11 +18,7 @@ jobs:
   # Checks if the comment contains '!rebuild images' and if the author is
   # an authorized user. Triggers the build job if conditions are met.
   check-comment-and-trigger-build:
-    if: |
-      contains(github.event.comment.body, '!rebuild images') &&
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'COLLABORATOR' ||
-       github.event.comment.author_association == 'MEMBER')
+    if: contains(github.event.comment.body, 'rebuild images')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Build Job

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,27 +1,20 @@
 # Workflow Description:
 # This GitHub Actions workflow is initiated by specific review comments from
-# authorized users in pull request reviews. It triggers a build and deployment
-# process when a comment containing '/rebuild'.
+# authorized users in pull request reviews. It automates the build and deployment
+# process when a comment containing '/rebuild' is detected.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
 # Triggers:
-# Activated by submitted reviews and comments in pull request reviews.
+# The workflow is activated by the creation of review comments in pull requests.
 on:
   pull_request_review_comment:
     types: [created]
 
 jobs:
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print Comment Body
-        run: |
-          echo "Comment Body: ${{ github.event.comment.body }}"
-
   # Job: Check Comment and Trigger Build
-  # Checks if the comment contains '/rebuild' and if the author is
-  # an authorized user. Triggers the build job if conditions are met.
+  # This job checks if the comment contains '/rebuild'. It triggers the subsequent
+  # build job only if this condition is met.
   check-comment-and-trigger-build:
     if: contains(github.event.comment.body, '/rebuild')
     runs-on: ubuntu-latest
@@ -30,12 +23,9 @@ jobs:
         run: echo "Triggering Build Job"
 
   # Job: Build Docker Image
-  # Builds Docker images for services listed in the matrix, depending on the
-  # 'check-comment-and-trigger-build' job's outcome.
   build:
     name: Build Docker Image - ${{ matrix.service }}
-    needs:
-      - check-comment-and-trigger-build
+    needs: check-comment-and-trigger-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,11 +40,12 @@ jobs:
           - schemaparser
           - dataproxyupdater
           - dataproxyrefresher
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }} # Check out head branch of PR.
+          ref: ${{ github.head_ref }} # Check out the PR's head branch.
 
       - name: DockerHub Login
         uses: docker/login-action@v3.0.0
@@ -66,8 +57,6 @@ jobs:
         run: make docker-push-${{ matrix.service }} DEPLOY_ENV=pretest
 
   # Job: Deploy Services
-  # Handles the deployment of services using the built Docker images.
-  # Depends on the successful completion of the 'build' job.
   deploy:
     name: Deploy Services
     needs: build
@@ -78,5 +67,10 @@ jobs:
       PRETEST_KUBECONFIG_PATH: ${{ secrets.PRETEST_KUBECONFIG_PATH }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }} # Check out the PR's head branch.
+
       - name: Run Deployment Script
         run: ./scripts/deploy-services.sh

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,21 +1,17 @@
 # Workflow Description:
 # This GitHub Actions workflow is initiated by specific review comments from
 # authorized users in pull request reviews. It triggers a build and deployment
-# process when a comment containing '/rebuild' is made by an authorized user.
+# process when a comment containing '/rebuild'.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
 # Triggers:
 # Activated by submitted reviews and comments in pull request reviews.
 on:
-  pull_request:
-    types: [opened]
-  issue_comment:
+  pull_request_review_comment:
     types: [created]
 
 jobs:
-  # Debug Job:
-  # Prints the body of the comment to the console for debugging purposes.
   debug:
     runs-on: ubuntu-latest
     steps:
@@ -23,25 +19,23 @@ jobs:
         run: |
           echo "Comment Body: ${{ github.event.comment.body }}"
 
-  # Check Comment and Trigger Build Job:
-  # Verifies if the comment contains '/rebuild' and if the author is an
-  # authorized user (OWNER or COLLABORATOR). Triggers the build job if true.
+  # Job: Check Comment and Trigger Build
+  # Checks if the comment contains '/rebuild' and if the author is
+  # an authorized user. Triggers the build job if conditions are met.
   check-comment-and-trigger-build:
-    if: >-
-      contains(github.event.comment.body, '/rebuild') &&
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'COLLABORATOR')
+    if: contains(github.event.comment.body, '/rebuild')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Build Job
         run: echo "Triggering Build Job"
 
-  # Build Job:
-  # Builds Docker images for the listed services, depending on the outcome of
-  # the 'check-comment-and-trigger-build' job.
+  # Job: Build Docker Image
+  # Builds Docker images for services listed in the matrix, depending on the
+  # 'check-comment-and-trigger-build' job's outcome.
   build:
     name: Build Docker Image - ${{ matrix.service }}
-    needs: check-comment-and-trigger-build
+    needs:
+      - check-comment-and-trigger-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,7 +54,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref }} # Check out head branch of PR.
 
       - name: DockerHub Login
         uses: docker/login-action@v3.0.0
@@ -71,9 +65,9 @@ jobs:
       - name: Publish Docker Image
         run: make docker-push-${{ matrix.service }} DEPLOY_ENV=pretest
 
-  # Deploy Job:
+  # Job: Deploy Services
   # Handles the deployment of services using the built Docker images.
-  # This job depends on the successful completion of the 'build' job.
+  # Depends on the successful completion of the 'build' job.
   deploy:
     name: Deploy Services
     needs: build

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -78,10 +78,6 @@ jobs:
   e2e_test:
     name: E2E Test
     needs:
-      - test
-      - lint
-      - check-exclusions
-      - build
       - deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,7 +1,7 @@
 # Workflow Description:
 # This GitHub Actions workflow is initiated by specific review comments from
 # authorized users in pull request reviews. It triggers a build and deployment
-# process when a comment containing '!rebuild images'.
+# process when a comment containing '/rebuild'.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
@@ -14,11 +14,18 @@ on:
     types: [created]
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print Comment Body
+        run: |
+          echo "Comment Body: ${{ github.event.comment.body }}"
+
   # Job: Check Comment and Trigger Build
-  # Checks if the comment contains '!rebuild images' and if the author is
+  # Checks if the comment contains '/rebuild' and if the author is
   # an authorized user. Triggers the build job if conditions are met.
   check-comment-and-trigger-build:
-    if: contains(github.event.comment.body, 'rebuild images')
+    if: contains(github.event.comment.body, '/rebuild')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Build Job

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,12 +1,13 @@
-# This workflow is designed to trigger a build and deployment process based
-# on specific review comments made by authorized users in pull request reviews.
-# When a comment containing '!rebuild images' is detected from an authorized user
-# (Owner, Collaborator, or Member), the workflow initiates a build job for
-# multiple Docker images and then proceeds to deploy these services.
+# Workflow Description:
+# This GitHub Actions workflow is initiated by specific review comments from
+# authorized users in pull request reviews. It triggers a build and deployment
+# process when a comment containing '!rebuild images' is made by an Owner,
+# Collaborator, or Member.
 
 name: Redeploy on Specific Review Comment by Authorized User
 
-# Trigger this workflow on comments created in pull request reviews.
+# Triggers:
+# Activated by submitted reviews and comments in pull request reviews.
 on:
   pull_request_review:
     types: [submitted]
@@ -14,6 +15,9 @@ on:
     types: [created]
 
 jobs:
+  # Job: Check Comment and Trigger Build
+  # Checks if the comment contains '!rebuild images' and if the author is
+  # an authorized user. Triggers the build job if conditions are met.
   check-comment-and-trigger-build:
     if: |
       contains(github.event.comment.body, '!rebuild images') &&
@@ -25,6 +29,9 @@ jobs:
       - name: Trigger Build Job
         run: echo "Triggering Build Job"
 
+  # Job: Build Docker Image
+  # Builds Docker images for services listed in the matrix, depending on the
+  # 'check-comment-and-trigger-build' job's outcome.
   build:
     name: Build Docker Image - ${{ matrix.service }}
     needs:
@@ -46,6 +53,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }} # Check out head branch of PR.
 
       - name: DockerHub Login
         uses: docker/login-action@v3.0.0
@@ -56,6 +65,9 @@ jobs:
       - name: Publish Docker Image
         run: make docker-push-${{ matrix.service }} DEPLOY_ENV=pretest
 
+  # Job: Deploy Services
+  # Handles the deployment of services using the built Docker images.
+  # Depends on the successful completion of the 'build' job.
   deploy:
     name: Deploy Services
     needs: build

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -74,3 +74,43 @@ jobs:
 
       - name: Run Deployment Script
         run: ./scripts/deploy-services.sh
+
+  e2e_test:
+    name: E2E Test
+    needs:
+      - test
+      - lint
+      - check-exclusions
+      - build
+      - deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Newman
+        run: |
+          npm install -g newman
+
+      - name: Test Index
+        run: >
+          ./scripts/wait_for_timeout.sh
+          https://pretest1-index.murmurations.network/v2/ping 200 300
+
+      - name: Test Library
+        run: >
+          ./scripts/wait_for_timeout.sh
+          https://pretest1-library.murmurations.network/v2/ping 200 300
+
+      - name: Test Data Proxy
+        run: >
+          ./scripts/wait_for_timeout.sh
+          https://pretest1-data-proxy.murmurations.network/v1/ping 200 300
+
+      - name: Newman E2E Test
+        run: make newman-test DEPLOY_ENV=pretest

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -1,0 +1,62 @@
+name: Redeploy on Specific Review Comment by Authorized User
+
+# Trigger this workflow on comments created in pull request reviews.
+on:
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  check-comment-and-trigger-build:
+    if: |
+      contains(github.event.comment.body, '!rebuild images') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR' ||
+       github.event.comment.author_association == 'MEMBER')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Build Job
+        run: echo "Triggering Build Job"
+
+  build:
+    name: Build Docker Image - ${{ matrix.service }}
+    needs:
+      - check-comment-and-trigger-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - index
+          - library
+          - geoip
+          - validation
+          - dataproxy
+          - nodecleaner
+          - revalidatenode
+          - schemaparser
+          - dataproxyupdater
+          - dataproxyrefresher
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: DockerHub Login
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish Docker Image
+        run: make docker-push-${{ matrix.service }} DEPLOY_ENV=pretest
+
+  deploy:
+    name: Deploy Services
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Deployment Script
+        run: ./scripts/deploy-services.sh
+        env:
+          PRETEST_SERVER_IP: ${{ secrets.PRETEST_SERVER_IP }}
+          PRETEST_KUBECONFIG_PATH: ${{ secrets.PRETEST_KUBECONFIG_PATH }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_ENV: pretest

--- a/.github/workflows/redeploy-on-comment.yml
+++ b/.github/workflows/redeploy-on-comment.yml
@@ -8,9 +8,9 @@ name: Redeploy on Specific Review Comment by Authorized User
 # Triggers:
 # Activated by submitted reviews and comments in pull request reviews.
 on:
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
+  pull_request:
+    types: [opened]
+  issue_comment:
     types: [created]
 
 jobs:


### PR DESCRIPTION
### Description:

Trigger a rebuild and redeploy of all services when **a commit to the code** includes `"/rebuild"`. 

#### Why not trigger by leaving comments in the PR?

The goal is to avoid triggering a job whenever someone leaves a comment. Otherwise, if many discussions occur in the PR, it could lead to multiple triggers. However, since code review commits are less frequent, excessive triggering is not a concern.

### Example:

Trigger by leaving a comment containing `/rebuild`.

![image](https://github.com/MurmurationsNetwork/MurmurationsServices/assets/11765228/d4dbc2b6-7501-471f-adb4-54eb5ace4067)

Result:

![image](https://github.com/MurmurationsNetwork/MurmurationsServices/assets/11765228/964ba8c4-2a28-48f7-8991-6e5048a742ed)

##

resolves #657