### PR TITLE
fix: update redis version

### DIFF
--- a/charts/murmurations/charts/schemaparser/templates/redis/dpl.yaml
+++ b/charts/murmurations/charts/schemaparser/templates/redis/dpl.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: leader
-        image: redis:6.2.6
+        image: redis:7.2.4
         resources:
           requests:
             memory: "16Mi"


### PR DESCRIPTION
We updated the redis package, which requires us to update the Redis version:

![image](https://github.com/MurmurationsNetwork/MurmurationsServices/assets/11765228/7f62221b-9291-4891-926e-e69de7d2fef1)
