### PR TITLE
NATS Config: Simplify Scheduling by Removing topologySpreadConstraints

### DIFF
--- a/charts/murm-queue/values-contabo.yaml
+++ b/charts/murm-queue/values-contabo.yaml
@@ -19,11 +19,3 @@ reloader:
 
 service:
   name: nats
-
-# Pod template configuration for Kubernetes.
-podTemplate:
-  # Define topology spread constraints for pod placement.
-  topologySpreadConstraints:
-    kubernetes.io/hostname:
-      maxSkew: 1  # Define the maximum skew between pods.
-      whenUnsatisfiable: DoNotSchedule  # Policy for when skew is unsatisfiable.

--- a/charts/murm-queue/values-dev.yaml
+++ b/charts/murm-queue/values-dev.yaml
@@ -20,11 +20,3 @@ reloader:
 
 service:
   name: nats
-
-# Pod template configuration for Kubernetes.
-podTemplate:
-  # Define topology spread constraints for pod placement.
-  topologySpreadConstraints:
-    kubernetes.io/hostname:
-      maxSkew: 1  # Define the maximum skew between pods.
-      whenUnsatisfiable: DoNotSchedule  # Policy for when skew is unsatisfiable.


### PR DESCRIPTION
TopologySpreadConstraints require that services be evenly distributed across all nodes, causing the service to fail if even one node is missing.